### PR TITLE
Fix: ci.yml and llvm-build.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,10 @@ jobs:
       - name: Set paths (mlir_wheel)
         if: ${{ inputs.mlir-source != 'custom' }}
         run: |
-          MLIR_DIR=$(uv run python -c \
+          MLIR_DIR=$(uv run --no-project python -c \
             "import mlir_wheel, pathlib; \
              print(pathlib.Path(mlir_wheel.__file__).parent / 'lib/cmake/mlir')")
-          LIT=$(uv run which lit)
+          LIT=$(uv run --no-project which lit)
           echo "MLIR_DIR=$MLIR_DIR" >> $GITHUB_ENV
           echo "LIT=$LIT"          >> $GITHUB_ENV
 
@@ -92,7 +92,7 @@ jobs:
         run: |
           tar -xzf llvm-${{ inputs.llvm-short-hash }}-${{ matrix.config.os }}-${{ matrix.config.arch }}.tar.gz
           MLIR_DIR="$(pwd)/llvm-${{ inputs.llvm-short-hash }}-${{ matrix.config.os }}-${{ matrix.config.arch }}/lib/cmake/mlir"
-          LIT=$(uv run which lit)
+          LIT=$(uv run --no-project which lit)
           echo "MLIR_DIR=$MLIR_DIR" >> $GITHUB_ENV
           echo "LIT=$LIT"          >> $GITHUB_ENV
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
           - mlir_wheel
           - custom
       llvm-short-hash:
-        description: "Short LLVM commit hash (required when mlir-source=custom)"
+        description: "First 8 characters of the LLVM commit SHA (required when mlir-source=custom)"
         required: false
         type: string
   workflow_call:
@@ -53,16 +53,75 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
+      # ── Resolve build configuration ─────────────────────────────────────────
+      # Determines the effective mlir-source and, for the custom path, locates
+      # the pre-built LLVM artifact in the parent repo (or self if not a fork).
+      #
+      # Hash resolution order:
+      #   1. inputs.llvm-short-hash  (workflow_dispatch / workflow_call)
+      #   2. cmake/llvm-hash.txt     (pull_request — no inputs available)
+      #
+      # If a hash is found, mlir-source is forced to 'custom' and the GitHub
+      # API is queried for the artifact. If no artifact is found, falls back
+      # to mlir_wheel with a warning.
+
+      - name: Resolve build configuration
+        id: config
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # 1. Resolve hash
+          SHORT_HASH="${{ inputs.llvm-short-hash }}"
+          if [ -z "$SHORT_HASH" ] && [ -f cmake/llvm-hash.txt ]; then
+            FULL_HASH=$(cat cmake/llvm-hash.txt)
+            SHORT_HASH="${FULL_HASH:0:8}"
+          fi
+
+          # 2. Resolve mlir-source
+          if [ -n "$SHORT_HASH" ]; then
+            MLIR_SOURCE="custom"
+          else
+            MLIR_SOURCE="${{ inputs.mlir-source }}"
+            [ -z "$MLIR_SOURCE" ] && MLIR_SOURCE="mlir_wheel"
+          fi
+
+          # 3. For custom path: find artifact repo and run-id via GitHub API
+          if [ "$MLIR_SOURCE" = "custom" ]; then
+            ARTIFACT_REPO=$(curl -sf \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              "https://api.github.com/repos/${{ github.repository }}" \
+              | jq -r '.parent.full_name // .full_name')
+
+            ARTIFACT_NAME="llvm-${SHORT_HASH}-${{ matrix.config.os }}-${{ matrix.config.arch }}"
+            RUN_ID=$(curl -sf \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts?name=${ARTIFACT_NAME}&per_page=1" \
+              | jq -r '.artifacts[0].workflow_run.id // empty')
+
+            if [ -z "$RUN_ID" ]; then
+              echo "::warning::Artifact ${ARTIFACT_NAME} not found in ${ARTIFACT_REPO}, falling back to mlir_wheel"
+              MLIR_SOURCE="mlir_wheel"
+            else
+              echo "artifact-repo=${ARTIFACT_REPO}" >> $GITHUB_OUTPUT
+              echo "run-id=${RUN_ID}"               >> $GITHUB_OUTPUT
+            fi
+          fi
+
+          echo "mlir-source=${MLIR_SOURCE}"       >> $GITHUB_OUTPUT
+          echo "llvm-short-hash=${SHORT_HASH}"     >> $GITHUB_OUTPUT
+
+      # ── Install dependencies ────────────────────────────────────────────────
       # --no-install-project in both paths: cmake is driven explicitly below
       # and we don't want scikit-build-core to run a project build here
       # (it enables Python bindings and fails if python sources are absent).
       # mlir_wheel is only needed for its cmake config (MLIR_DIR).
+
       - name: Install dependencies (mlir_wheel)
-        if: ${{ inputs.mlir-source != 'custom' }}
+        if: steps.config.outputs.mlir-source != 'custom'
         run: uv sync --no-install-project --extra mlir --extra test
 
       - name: Install dependencies (custom LLVM)
-        if: ${{ inputs.mlir-source == 'custom' }}
+        if: steps.config.outputs.mlir-source == 'custom'
         run: uv sync --no-install-project --extra test
 
       # ── Path resolution ─────────────────────────────────────────────────────
@@ -70,7 +129,7 @@ jobs:
       # below is identical regardless of MLIR source.
 
       - name: Set paths (mlir_wheel)
-        if: ${{ inputs.mlir-source != 'custom' }}
+        if: steps.config.outputs.mlir-source != 'custom'
         run: |
           MLIR_DIR=$(uv run --no-project python -c \
             "import mlir_wheel, pathlib; \
@@ -80,18 +139,19 @@ jobs:
           echo "LIT=$LIT"          >> $GITHUB_ENV
 
       - name: Download LLVM artifact (custom LLVM)
-        if: ${{ inputs.mlir-source == 'custom' }}
+        if: steps.config.outputs.mlir-source == 'custom'
         uses: actions/download-artifact@v4
         with:
-          # Artifact name matches what llvm-build.yml uploads:
-          # llvm-<short-hash>-<os>-<arch>.tar.gz
-          name: llvm-${{ inputs.llvm-short-hash }}-${{ matrix.config.os }}-${{ matrix.config.arch }}
+          name:         llvm-${{ steps.config.outputs.llvm-short-hash }}-${{ matrix.config.os }}-${{ matrix.config.arch }}
+          run-id:       ${{ steps.config.outputs.run-id }}
+          repository:   ${{ steps.config.outputs.artifact-repo }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set paths (custom LLVM)
-        if: ${{ inputs.mlir-source == 'custom' }}
+        if: steps.config.outputs.mlir-source == 'custom'
         run: |
-          tar -xzf llvm-${{ inputs.llvm-short-hash }}-${{ matrix.config.os }}-${{ matrix.config.arch }}.tar.gz
-          MLIR_DIR="$(pwd)/llvm-${{ inputs.llvm-short-hash }}-${{ matrix.config.os }}-${{ matrix.config.arch }}/lib/cmake/mlir"
+          tar -xzf llvm-${{ steps.config.outputs.llvm-short-hash }}-${{ matrix.config.os }}-${{ matrix.config.arch }}.tar.gz
+          MLIR_DIR="$(pwd)/llvm-${{ steps.config.outputs.llvm-short-hash }}-${{ matrix.config.os }}-${{ matrix.config.arch }}/lib/cmake/mlir"
           LIT=$(uv run --no-project which lit)
           echo "MLIR_DIR=$MLIR_DIR" >> $GITHUB_ENV
           echo "LIT=$LIT"          >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,12 +53,13 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
-      # mlir_wheel path: installs mlir_wheel (provides MLIR cmake config) + lit.
-      # custom path: --no-install-project skips the scikit-build-core project
-      # build (which needs MLIR_DIR); only installs lit for check-ktir.
+      # --no-install-project in both paths: cmake is driven explicitly below
+      # and we don't want scikit-build-core to run a project build here
+      # (it enables Python bindings and fails if python sources are absent).
+      # mlir_wheel is only needed for its cmake config (MLIR_DIR).
       - name: Install dependencies (mlir_wheel)
         if: ${{ inputs.mlir-source != 'custom' }}
-        run: uv sync --extra mlir --extra test
+        run: uv sync --no-install-project --extra mlir --extra test
 
       - name: Install dependencies (custom LLVM)
         if: ${{ inputs.mlir-source == 'custom' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,18 +92,23 @@ jobs:
               "https://api.github.com/repos/${{ github.repository }}" \
               | jq -r '.parent.full_name // .full_name')
 
-            ARTIFACT_NAME="llvm-${SHORT_HASH}-${{ matrix.config.os }}-${{ matrix.config.arch }}"
-            RUN_ID=$(curl -sf \
-              -H "Authorization: Bearer $GH_TOKEN" \
-              "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts?name=${ARTIFACT_NAME}&per_page=1" \
-              | jq -r '.artifacts[0].workflow_run.id // empty')
-
-            if [ -z "$RUN_ID" ]; then
-              echo "::warning::Artifact ${ARTIFACT_NAME} not found in ${ARTIFACT_REPO}, falling back to mlir_wheel"
+            if [ -z "$ARTIFACT_REPO" ]; then
+              echo "::warning::Could not resolve artifact repository for ${{ github.repository }}, falling back to mlir_wheel"
               MLIR_SOURCE="mlir_wheel"
             else
-              echo "artifact-repo=${ARTIFACT_REPO}" >> $GITHUB_OUTPUT
-              echo "run-id=${RUN_ID}"               >> $GITHUB_OUTPUT
+              ARTIFACT_NAME="llvm-${SHORT_HASH}-${{ matrix.config.os }}-${{ matrix.config.arch }}"
+              RUN_ID=$(curl -sf \
+                -H "Authorization: Bearer $GH_TOKEN" \
+                "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts?name=${ARTIFACT_NAME}&per_page=1" \
+                | jq -r '.artifacts[0].workflow_run.id // empty')
+
+              if [ -z "$RUN_ID" ]; then
+                echo "::warning::Artifact ${ARTIFACT_NAME} not found in ${ARTIFACT_REPO}, falling back to mlir_wheel"
+                MLIR_SOURCE="mlir_wheel"
+              else
+                echo "artifact-repo=${ARTIFACT_REPO}" >> $GITHUB_OUTPUT
+                echo "run-id=${RUN_ID}"               >> $GITHUB_OUTPUT
+              fi
             fi
           fi
 

--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
     inputs:
       llvm-hash:
-        description: "LLVM commit hash to build (overrides cmake/llvm-hash.txt)"
+        description: "Full 40-character LLVM commit SHA to build (overrides cmake/llvm-hash.txt)"
         required: false
         type: string
 
@@ -111,6 +111,15 @@ jobs:
         with:
           name: ${{ env.LLVM_INSTALL_DIR }}
           path: ${{ env.LLVM_INSTALL_DIR }}.tar.gz
+          # Artifacts are only needed to pass to ci.yml immediately after this
+          # workflow completes. 3 days covers manual reruns without accumulating
+          # storage over the 90-day default.
+          retention-days: 3
+          # Without overwrite, re-running with the same hash creates duplicate
+          # artifacts with the same name. download-artifact@v4 then becomes
+          # ambiguous when triggered outside of this workflow (e.g. workflow_dispatch
+          # on ci.yml). overwrite keeps exactly one artifact per hash/os/arch.
+          overwrite: true
 
       - name: Dump sccache statistics
         run: sccache --show-stats

--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -83,9 +83,6 @@ jobs:
           key:          ${{ matrix.config.os }}-${{ matrix.config.arch }}-${{ needs.get-hash.outputs.llvm-short-hash }}
           restore-keys: ${{ matrix.config.os }}-${{ matrix.config.arch }}-
 
-      - name: Clear sccache
-        run: mkdir -p ${{ env.SCCACHE_DIR }} && rm -rf ${{ env.SCCACHE_DIR }}/*
-
       - name: Configure LLVM
         run: >
           cmake -GNinja -B llvm-project/build

--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -34,10 +34,13 @@ jobs:
       - name: Read LLVM commit hash
         id: read
         run: |
-          # workflow_dispatch input takes precedence over the pinned file
+          # workflow_dispatch input takes precedence over the pinned file.
+          # If neither is present, fall back to empty string — downstream jobs
+          # that need a hash (build) will skip; jobs that don't (trigger-ci
+          # with mlir_wheel) are unaffected.
           LLVM_HASH="${{ inputs.llvm-hash }}"
           if [ -z "$LLVM_HASH" ]; then
-            LLVM_HASH=$(cat cmake/llvm-hash.txt)
+            LLVM_HASH=$(cat cmake/llvm-hash.txt 2>/dev/null || echo "")
           fi
           echo "llvm-hash=$LLVM_HASH"             >> $GITHUB_OUTPUT
           echo "llvm-short-hash=${LLVM_HASH:0:8}" >> $GITHUB_OUTPUT
@@ -45,6 +48,7 @@ jobs:
   build:
     name: Build LLVM (${{ matrix.config.runner }})
     needs: get-hash
+    if: ${{ needs.get-hash.outputs.llvm-hash != '' }}
     runs-on: ${{ matrix.config.runs-on }}
 
     strategy:
@@ -124,10 +128,14 @@ jobs:
       - name: Dump sccache statistics
         run: sccache --show-stats
 
-  # Trigger CI with the freshly built LLVM artifacts.
+  # Trigger CI against the freshly built LLVM artifact.
+  # Only runs when a hash was resolved — ci.yml already runs independently
+  # on push/PR with mlir_wheel, so triggering it here with mlir_wheel would
+  # be a duplicate.
   trigger-ci:
     needs: [get-hash, build]
+    if: ${{ needs.get-hash.outputs.llvm-hash != '' }}
     uses: ./.github/workflows/ci.yml
     with:
-      mlir-source:      custom
-      llvm-short-hash:  ${{ needs.get-hash.outputs.llvm-short-hash }}
+      mlir-source:     custom
+      llvm-short-hash: ${{ needs.get-hash.outputs.llvm-short-hash }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR ON)
 
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to conform to")
 
+option(KTIR_ENABLE_PYTHON_BINDINGS "Build Python bindings" OFF)
+
 find_package(MLIR REQUIRED CONFIG)
 
 # Define the default argument to use by `lit` when testing.
@@ -34,7 +36,8 @@ add_definitions(${LLVM_DEFINITIONS})
 
 add_subdirectory(include)
 add_subdirectory(lib)
-if(MLIR_ENABLE_BINDINGS_PYTHON)
+if(KTIR_ENABLE_PYTHON_BINDINGS)
+  set(MLIR_ENABLE_BINDINGS_PYTHON ON)
   include(MLIRDetectPythonEnv)
   mlir_configure_python_dev_packages()
   if(NOT MLIR_PYTHON_PACKAGE_PREFIX)


### PR DESCRIPTION
# Fix: cmake-test and llvm-build

## Test Status

| Part | Workflow | `mlir-source` | Speed | Status |
|---|---|---|---|---|
| 1 | `ci.yml` → `cmake-test` | `mlir_wheel` | ⚡ Fast — prebuilt wheel, no LLVM compile | ✅ Passed |
| 2 | `llvm-build.yml` → `build` → `trigger-ci` | `custom` | 🐢 Slow — full LLVM build (~1h, ~1GB artifact) | ✅ Build passed — see [github action](https://github.com/torch-spyre/ktir-mlir-frontend/actions/runs/24288875086/job/70922784508); `trigger-ci` → `cmake-test` cannot be tested until merged |
| 3 | `ci.yml` → `cmake-test` | `custom` | ⚡ Fast — reuses artifact from Path 2 | ✅ Passed — [fork workflow_dispatch](https://github.com/fabianlim/ktir-mlir-frontend/actions/runs/24349727570) (but still need to address artifact freshness issue) |

The two skipped checks (`build`, `trigger-ci`) will always appear in PRs — they only run when an LLVM build is needed.

---

## Path 1: `mlir-source=mlir_wheel` (tested)

Three fixes were needed, all caused by `uv` or `mlir_wheel` triggering an unintended cmake build:

- **`uv sync --no-install-project`** and **`uv run --no-project`**: without these flags, uv installs the project in editable mode via scikit-build-core before running any command. This triggers a cmake build with `-DKTIR_ENABLE_PYTHON_BINDINGS=ON`, which fails because python source files are absent on this branch.
- **`CMakeLists.txt` guard** (from `python-packaging` branch): `mlir_wheel`'s `MLIRConfig.cmake` unconditionally sets `MLIR_ENABLE_BINDINGS_PYTHON=ON`, causing nanobind detection to run even with `-DKTIR_ENABLE_PYTHON_BINDINGS=OFF`. Fixed by introducing a project-local `KTIR_ENABLE_PYTHON_BINDINGS` option as the guard instead.

---

## Path 2: `mlir-source=custom` — LLVM build (partially tested)

`llvm-build.yml` builds LLVM from a pinned commit and uploads a GitHub Actions artifact
(`llvm-<short-hash>-<os>-<arch>.tar.gz`). Two ways to trigger:

- **`push` on `cmake/llvm-hash.txt`**: fires automatically when the hash changes on `main`. Not active yet — file not committed. This is the flow Triton adopts.
- **`workflow_dispatch`**: provide the full 40-char LLVM SHA in the `llvm-hash` input.

Tested in this PR by: Actions → LLVM Build → Run Workflow → hash `3b3ac5a1169722bff1ae0f5f8f27a48cc08c3d02`
- Build ran and artifact was cached. Total size was **~1GB** — worth trimming in future (strip static libs, disable unused tools).

<details>
<summary>Artifact stored in torch-spyre/ktir-mlir-frontend</summary>

```json
{
  "id": 6388171867,
  "name": "llvm-3b3ac5a1-ubuntu-x64",
  "size_in_bytes": 1057486279,
  "archive_download_url": "https://api.github.com/repos/torch-spyre/ktir-mlir-frontend/actions/artifacts/6388171867/zip",
  "expired": false,
  "expires_at": "2026-07-10T18:32:28Z"
}
```
</details>

Build artifacts can be potentially distributed for local development:
- avoiding mindless rebuilding amongst users

```
curl -L -H "Authorization: token $GIT_PAT" \
    https://api.github.com/repos/torch-spyre/ktir-mlir-frontend/actions/artifacts/6388171867/zip \
    -o llvm-3b3ac5a1-ubuntu-x64.zip
```


---

## Path 3: `mlir-source=custom` with pre-built artifact (tested)

This path has `ci.yml` download the artifact produced by `llvm-build.yml` and run
Configure/Build/Test against it. Tested via `workflow_dispatch` from a fork:
[fabianlim/ktir-mlir-frontend run 24349727570](https://github.com/fabianlim/ktir-mlir-frontend/actions/runs/24349727570).

`Resolve build configuration` step queries the GitHub API to
auto-resolve the artifact repo (parent if fork, self otherwise) and look up the `run-id`
by artifact name. No extra inputs required. Works for `workflow_dispatch` from a fork,
`pull_request`, and `workflow_call` from `llvm-build.yml`.

### Problem: Artifact freshness

Retention is 3 days. If the artifact expires before `ci.yml` is triggered with
`mlir-source=custom`, the download step fails. Options:

- **Scheduled rebuild** (e.g. every 2 days): keeps artifact alive via `overwrite: true` + retention reset. sccache makes reruns cheap. Requires `cmake/llvm-hash.txt` on `main`; GitHub auto-disables schedules after 60 days of inactivity.
- **Increase retention** (e.g. 7–30 days): simple but higher storage cost.
- **Self-provisioned store** (S3, Artifactory, Azure Blob): no expiry, no quota concerns. Replaces `upload/download-artifact` with `curl`/`rclone` + credentials in Secrets. Triton uses Azure Blob for the same reason.
