### PR TITLE
[Ktdp] Remove L0 memory space from SpyreMemorySpaceKind

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The `ktdp` dialect models tile-based, data-parallel kernels targeting multi-core
 
 Custom types: `!ktdp.access_tile<NxMxindex>`, `!ktdp.runtime_arg<type, granularity=N, upperbound=M>`
 
-Memory spaces: `#ktdp.spyre_memory_space<HBM>`, `<LX, core=7>`, `<L0>`, `<unspecified>`
+Memory spaces: `#ktdp.spyre_memory_space<HBM>`, `<LX, core=7>`, `<unspecified>`
 
 ## How to Build
 

--- a/include/Ktdp/KtdpAttrs.td
+++ b/include/Ktdp/KtdpAttrs.td
@@ -25,8 +25,7 @@ def Ktdp_SpyreMemorySpaceKind : I32EnumAttr<
     [
       I32EnumAttrCase<"unspecified", 0, "unspecified">,
       I32EnumAttrCase<"LX",  1, "LX">,
-      I32EnumAttrCase<"HBM", 2, "HBM">,
-      I32EnumAttrCase<"L0",  3, "L0">
+      I32EnumAttrCase<"HBM", 2, "HBM">
     ]> {
   let cppNamespace = "::mlir::ktdp";
   let genSpecializedAttr = 0;
@@ -55,11 +54,10 @@ def Ktdp_MemorySpaceAttr : AttrInterface<"KtdpMemorySpaceAttr"> {
 // Assembly syntax:
 //   #ktdp.spyre_memory_space<HBM>
 //   #ktdp.spyre_memory_space<LX, core = 7>
-//   #ktdp.spyre_memory_space<L0>
 //   #ktdp.spyre_memory_space<unspecified>
 //
 // Parameters:
-//   value  -- SpyreMemorySpaceKind enum (unspecified | LX | HBM | L0)
+//   value  -- SpyreMemorySpaceKind enum (unspecified | LX | HBM)
 //   core   -- optional core affinity (default -1 = unspecified)
 //===----------------------------------------------------------------------===//
 
@@ -75,10 +73,9 @@ def Ktdp_SpyreMemorySpaceAttr
     - `unspecified` -- memory space not yet determined.
     - `LX`  -- shared on-chip scratchpad (cross-core accessible).
     - `HBM` -- high-bandwidth off-chip memory.
-    - `L0`  -- per-core on-chip scratchpad.
 
     The optional `core` parameter identifies which compute core's local
-    memory is referenced (relevant for `LX` and `L0`).
+    memory is referenced (relevant for `LX`).
 
     Examples:
     ```mlir

--- a/lib/Ktdp/KtdpAttrs.cpp
+++ b/lib/Ktdp/KtdpAttrs.cpp
@@ -23,10 +23,9 @@ LogicalResult SpyreMemorySpaceAttr::verify(
     return emitError() << "core affinity must be non-negative, but got: "
                        << core;
 
-  if (value != SpyreMemorySpaceKind::LX &&
-      value != SpyreMemorySpaceKind::L0) {
+  if (value != SpyreMemorySpaceKind::LX) {
     return emitError()
-           << "core affinity is only valid for LX or L0 memory spaces, "
+           << "core affinity is only valid for LX memory spaces, "
               "but got memory space '"
            << stringifySpyreMemorySpaceKind(value) << "' with core = " << core;
   }

--- a/test/Ktdp/attrs-roundtrip.mlir
+++ b/test/Ktdp/attrs-roundtrip.mlir
@@ -12,12 +12,6 @@ func.func @memspace_lx(%arg0: memref<64xf32, #ktdp.spyre_memory_space<LX>>) -> m
   return %arg0 : memref<64xf32, #ktdp.spyre_memory_space<LX>>
 }
 
-// CHECK-LABEL: func.func @memspace_l0
-// CHECK-SAME: memref<64xf32, #ktdp.spyre_memory_space<L0>>
-func.func @memspace_l0(%arg0: memref<64xf32, #ktdp.spyre_memory_space<L0>>) -> memref<64xf32, #ktdp.spyre_memory_space<L0>> {
-  return %arg0 : memref<64xf32, #ktdp.spyre_memory_space<L0>>
-}
-
 // CHECK-LABEL: func.func @memspace_unspecified
 // CHECK-SAME: memref<64xf32, #ktdp.spyre_memory_space<unspecified>>
 func.func @memspace_unspecified(%arg0: memref<64xf32, #ktdp.spyre_memory_space<unspecified>>) -> memref<64xf32, #ktdp.spyre_memory_space<unspecified>> {
@@ -28,12 +22,6 @@ func.func @memspace_unspecified(%arg0: memref<64xf32, #ktdp.spyre_memory_space<u
 // CHECK-SAME: memref<64xf32, #ktdp.spyre_memory_space<LX, core = 7>>
 func.func @memspace_lx_core(%arg0: memref<64xf32, #ktdp.spyre_memory_space<LX, core = 7>>) -> memref<64xf32, #ktdp.spyre_memory_space<LX, core = 7>> {
   return %arg0 : memref<64xf32, #ktdp.spyre_memory_space<LX, core = 7>>
-}
-
-// CHECK-LABEL: func.func @memspace_l0_core
-// CHECK-SAME: memref<64xf32, #ktdp.spyre_memory_space<L0, core = 3>>
-func.func @memspace_l0_core(%arg0: memref<64xf32, #ktdp.spyre_memory_space<L0, core = 3>>) -> memref<64xf32, #ktdp.spyre_memory_space<L0, core = 3>> {
-  return %arg0 : memref<64xf32, #ktdp.spyre_memory_space<L0, core = 3>>
 }
 
 // CHECK-LABEL: func.func @memspace_lx_core_zero

--- a/test/Ktdp/attrs-verify-negative.mlir
+++ b/test/Ktdp/attrs-verify-negative.mlir
@@ -2,7 +2,7 @@
 
 // Core affinity on HBM should fail.
 func.func @memspace_hbm_core_invalid(%arg0: memref<64xf32,
-    // expected-error @+1 {{core affinity is only valid for LX or L0 memory spaces, but got memory space 'HBM' with core = 2}}
+    // expected-error @+1 {{core affinity is only valid for LX memory spaces, but got memory space 'HBM' with core = 2}}
     #ktdp.spyre_memory_space<HBM, core = 2>>) {
   return
 }
@@ -11,7 +11,7 @@ func.func @memspace_hbm_core_invalid(%arg0: memref<64xf32,
 
 // Core affinity on unspecified should fail.
 func.func @memspace_unspecified_core_invalid(%arg0: memref<64xf32,
-    // expected-error @+1 {{core affinity is only valid for LX or L0 memory spaces, but got memory space 'unspecified' with core = 0}}
+    // expected-error @+1 {{core affinity is only valid for LX memory spaces, but got memory space 'unspecified' with core = 0}}
     #ktdp.spyre_memory_space<unspecified, core = 0>>) {
   return
 }

--- a/test/Ktdp/invalid.mlir
+++ b/test/Ktdp/invalid.mlir
@@ -42,7 +42,7 @@ func.func @bad_distributed_rank(%a: memref<32x64xf16>, %b: memref<64xf16>) -> me
 #set_bad = affine_set<(d0, d1) : (d0 >= 0, -d0 + 31 >= 0, d1 >= 0, -d1 + 63 >= 0)>
 func.func @bad_core_affinity_hbm(%addr: index) -> memref<32x64xf16> {
   %view = ktdp.construct_memory_view %addr, sizes: [32, 64], strides: [64, 1] {
-    // expected-error @+1 {{core affinity is only valid for LX or L0 memory spaces}}
+    // expected-error @+1 {{core affinity is only valid for LX memory spaces}}
     coordinate_set = #set_bad, memory_space = #ktdp.spyre_memory_space<HBM, core = 3>
   } : memref<32x64xf16>
   return %view : memref<32x64xf16>


### PR DESCRIPTION
Closes #18

## Summary

- Remove `L0` (value = 3) from `SpyreMemorySpaceKind` in `include/Ktdp/KtdpAttrs.td`
- Update core-affinity guard in `lib/Ktdp/KtdpAttrs.cpp` to only allow `LX`; update error message accordingly
- Remove `@memspace_l0` and `@memspace_l0_core` test functions from `test/Ktdp/attrs-roundtrip.mlir`
- Update expected error messages in `test/Ktdp/attrs-verify-negative.mlir` and `test/Ktdp/invalid.mlir`
- Update README and doc comments to remove `L0` references

## Test plan

- [x] All 17 LIT tests pass (`uv run lit -sv build/test/Ktdp/`)

cc @viji560 @Prasanth-Chatarasi @kiszk @mudhakar @lchu6

🤖 Generated with [Claude Code](https://claude.com/claude-code)