### PR TITLE
KTDP inter-tile communication: all-reduce + single-reduce (produce + reduce)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,13 @@ The `ktdp` dialect models tile-based, data-parallel kernels targeting multi-core
 - **Data movement**: `load`, `store` (driven by access tiles)
 - **Tile identity**: `get_compute_tile_id`
 - **Runtime args**: `runtime_arg` type + `runtime_arg_extract` op
+- **Inter-tile communication**: `inter_tile_produce` + `inter_tile_reduce`
+  (all-reduce; `yield_partial` / `yield_reduced` terminators). See
+  [docs/inter-tile-communication.md](docs/inter-tile-communication.md). Broadcast
+  (`inter_tile_consume`), reduce-scatter, per-tile sync, gather, and scatter are
+  future work.
 
-Custom types: `!ktdp.access_tile<NxMxindex>`, `!ktdp.runtime_arg<type, granularity=N, upperbound=M>`
+Custom types: `!ktdp.access_tile<NxMxindex>`, `!ktdp.runtime_arg<type, granularity=N, upperbound=M>`, `!ktdp.tile_future<T_p_1, ...>`
 
 Memory spaces: `#ktdp.spyre_memory_space<HBM>`, `<LX, core=7>`, `<unspecified>`
 

--- a/include/Ktdp/KtdpOps.td
+++ b/include/Ktdp/KtdpOps.td
@@ -73,6 +73,164 @@ def KTDP_RegionTerminatorOp : Ktdp_Op<"region_terminator", [Terminator]> {
   let assemblyFormat = "attr-dict";
 }
 
+//===----------------------------------------------------------------------===//
+// Inter-tile communication
+//
+// Implements the design in docs/inter-tile-communication.md. This first cut
+// covers the all-reduce pattern: `ktdp.inter_tile_produce` (production) +
+// `ktdp.inter_tile_reduce` (reduction delivery), full-barrier synchronization.
+// Broadcast (`inter_tile_consume`), reduce-scatter, per-tile synchronization
+// (`producer_dependency_per_consumer`), gather, and scatter are future work;
+// the `!ktdp.tile_future` type and these terminators are shared scaffolding for
+// them.
+//===----------------------------------------------------------------------===//
+
+def KTDP_YieldPartialOp : Ktdp_Op<"yield_partial",
+    [Terminator, ReturnLike, Pure,
+     HasParent<"::mlir::ktdp::InterTileProduceOp">]> {
+  let summary = "Terminator naming a tile's partial contributions";
+  let description = [{
+    Terminates the producer region of `ktdp.inter_tile_produce`, yielding one
+    value per partial-tensor role. The yielded value types must match the
+    partial types carried by the produced `!ktdp.tile_future`.
+  }];
+  let arguments = (ins Variadic<AnyTensor>:$values);
+  let assemblyFormat = "($values^ `:` type($values))? attr-dict";
+}
+
+def KTDP_YieldReducedOp : Ktdp_Op<"yield_reduced",
+    [Terminator, ReturnLike, Pure,
+     ParentOneOf<["::mlir::ktdp::InterTileReduceOp"]>]> {
+  let summary = "Terminator yielding the combined partials of a reducer region";
+  let description = [{
+    Terminates the reducer region of `ktdp.inter_tile_reduce` (and, in future,
+    `ktdp.inter_tile_reduce_scatter`), yielding one combined value per
+    partial-tensor role. The yielded value types must match the partial types
+    `T_p_i` (not the rank-reduced result types).
+  }];
+  let arguments = (ins Variadic<AnyTensor>:$values);
+  let assemblyFormat = "($values^ `:` type($values))? attr-dict";
+}
+
+def KTDP_InterTileProduceOp : Ktdp_Op<"inter_tile_produce",
+    [SingleBlockImplicitTerminator<"::mlir::ktdp::YieldPartialOp">,
+     RecursiveMemoryEffects]> {
+  let summary = "Unified production op for inter-tile communication";
+  let description = [{
+    The `ktdp.inter_tile_produce` operation names **what partial results each
+    tile contributes** to a cross-tile communication and returns a
+    `!ktdp.tile_future` handle carrying per-tile availability signals.
+
+    The producer region runs once per participating tile in that tile's SPMD
+    execution. Its single block argument `%gid : index` is the index of the
+    group the tile belongs to (the runtime binds tile `t` to the group `g`
+    whose `producer_tiles_per_group(g)` contains `t`). The block terminates
+    with `ktdp.yield_partial`, naming the per-tile contribution for each role.
+
+    Attributes:
+    - `producer_tiles_per_group` — parameterized affine integer set `(i)[g]`
+      selecting which tiles produce per group.
+    - `groups` — affine integer set defining the range of valid group indices.
+
+    The result `!ktdp.tile_future` must have exactly one use: the single
+    delivery op that consumes it.
+
+    Example:
+    ```mlir
+    %f = ktdp.inter_tile_produce
+        producer_tiles_per_group = affine_set<(i)[g] : (i - 4*g >= 0, -i + 4*g + 3 >= 0)>,
+        groups                   = affine_set<(g) : (g >= 0, -g + 7 >= 0)>
+        : tensor<1x64xf16> -> !ktdp.tile_future<tensor<1x64xf16>>
+    {
+      ^bb0(%gid: index):
+        ktdp.yield_partial %partial : tensor<1x64xf16>
+    }
+    ```
+  }];
+
+  let arguments = (ins
+    Builtin_IntegerSetAttr:$producer_tiles_per_group,
+    Builtin_IntegerSetAttr:$groups);
+  let results = (outs Ktdp_TileFutureType:$future);
+  let regions = (region SizedRegion<1>:$body);
+
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    /// Convenience: the partial types carried by the produced future.
+    ::llvm::ArrayRef<::mlir::Type> getPartialTypes() {
+      return ::llvm::cast<TileFutureType>(getFuture().getType())
+          .getPartialTypes();
+    }
+  }];
+}
+
+def KTDP_InterTileReduceOp : Ktdp_Op<"inter_tile_reduce",
+    [SingleBlockImplicitTerminator<"::mlir::ktdp::YieldReducedOp">,
+     RecursiveMemoryEffects]> {
+  let summary = "Reduction delivery op (all-reduce / reduce)";
+  let description = [{
+    The `ktdp.inter_tile_reduce` operation consumes the `!ktdp.tile_future`
+    produced by `ktdp.inter_tile_produce` and combines the partials of every
+    producer tile in each group with an associative-commutative combiner,
+    delivering the fully reduced result to the consumer tiles.
+
+    The reducer region receives `2N` block arguments
+    (`%lhs_1..%lhs_N, %rhs_1..%rhs_N`, each of partial type `T_p_i`) and
+    terminates with `ktdp.yield_reduced`, yielding `N` combined values of the
+    partial types. The combiner must be pure.
+
+    Attributes:
+    - `consumer_tiles_per_group` — tiles that receive the reduced result.
+    - `groups` — must match the corresponding `inter_tile_produce`.
+    - `producer_dependency_per_consumer` *(optional)* — per-tile dependency
+      set; when absent, full-barrier semantics (all producers contribute).
+
+    `identity` provides one identity tensor per role (matching `T_p_i`),
+    hoisted before the op and shared across groups/tiles.
+
+    Each result `T_r_i` is `T_p_i` with the within-group tile axes collapsed.
+    Every consumer tile in a group holds that group's fully reduced result
+    (all-reduce when consumer set == producer set).
+
+    Example:
+    ```mlir
+    %r = ktdp.inter_tile_reduce(%f)
+        consumer_tiles_per_group = affine_set<(i)[g] : (i - 4*g >= 0, -i + 4*g + 3 >= 0)>,
+        groups                   = affine_set<(g) : (g >= 0, -g + 7 >= 0)>,
+        identity(%add_id : tensor<1x64xf16>)
+        : !ktdp.tile_future<tensor<1x64xf16>> -> tensor<64xf16>
+    {
+      ^bb0(%lhs: tensor<1x64xf16>, %rhs: tensor<1x64xf16>):
+        %s = linalg.add ins(%lhs, %rhs : tensor<1x64xf16>, tensor<1x64xf16>)
+                        outs(%lhs : tensor<1x64xf16>) -> tensor<1x64xf16>
+        ktdp.yield_reduced %s : tensor<1x64xf16>
+    }
+    ```
+  }];
+
+  let arguments = (ins
+    Ktdp_TileFutureType:$future,
+    Variadic<AnyTensor>:$identity,
+    Builtin_IntegerSetAttr:$consumer_tiles_per_group,
+    Builtin_IntegerSetAttr:$groups,
+    OptionalAttr<Builtin_IntegerSetAttr>:$producer_dependency_per_consumer);
+  let results = (outs Variadic<AnyTensor>:$results);
+  let regions = (region SizedRegion<1>:$combiner);
+
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    /// Convenience: the partial types carried by the consumed future.
+    ::llvm::ArrayRef<::mlir::Type> getPartialTypes() {
+      return ::llvm::cast<TileFutureType>(getFuture().getType())
+          .getPartialTypes();
+    }
+  }];
+}
+
 def KTDP_GetComputeTileIdOp : Ktdp_Op<"get_compute_tile_id",
   [Pure]> {
     let summary = "Gets the id of the current compute tile";

--- a/include/Ktdp/KtdpTypes.td
+++ b/include/Ktdp/KtdpTypes.td
@@ -213,4 +213,58 @@ def Ktdp_RuntimeArgType : KTDP_Type<"RuntimeArg", "runtime_arg"> {
   let genVerifyDecl = 1;
 }
 
+//===----------------------------------------------------------------------===//
+// TileFutureType
+//===----------------------------------------------------------------------===//
+
+def Ktdp_TileFutureType : KTDP_Type<"TileFuture", "tile_future"> {
+  let summary = "Workgroup-visible handle to in-flight per-tile partial contributions";
+  let hasCustomAssemblyFormat = 1;
+  let description = [{
+    Syntax:
+
+    ```
+    tile_future-type ::= `tile_future` `<` type (`,` type)* `>`
+    ```
+
+    The `tile_future` type is the SSA handle returned by
+    `ktdp.inter_tile_produce`. It carries one or more *partial-tensor roles*
+    (the variadic `T_p_1, ..., T_p_N`), each a ranked tensor describing what a
+    producer tile contributes to the cross-tile communication. The def-use edge
+    from the producing op to the single consuming delivery op
+    (`inter_tile_consume` / `inter_tile_reduce` / `inter_tile_reduce_scatter`)
+    encodes the happens-before ordering with no explicit barriers in the IR.
+
+    N >= 1 roles are supported; N >= 2 expresses correlated tuples such as the
+    (values, indices) pair of an argmax-style reduction.
+
+    Examples:
+
+    ```mlir
+    // Single partial role.
+    !ktdp.tile_future<tensor<1x64xf16>>
+
+    // Two correlated roles (argmax-style: values, indices).
+    !ktdp.tile_future<tensor<128xf32>, tensor<128xi32>>
+    ```
+  }];
+
+  let parameters = (ins ArrayRefParameter<"::mlir::Type">:$partialTypes);
+
+  let builders = [
+    TypeBuilderWithInferredContext<(ins
+      "::llvm::ArrayRef<::mlir::Type>":$partialTypes
+    ), [{
+      return $_get(partialTypes.front().getContext(), partialTypes);
+    }]>
+  ];
+
+  let extraClassDeclaration = [{
+    /// Number of partial-tensor roles carried by this future.
+    size_t getNumPartials() const { return getPartialTypes().size(); }
+  }];
+
+  let genVerifyDecl = 1;
+}
+
 #endif // KTDP_TYPES_TD

--- a/lib/Ktdp/CMakeLists.txt
+++ b/lib/Ktdp/CMakeLists.txt
@@ -18,5 +18,4 @@ add_mlir_dialect_library(MLIRKtdp
   MLIRIR
   MLIRInferTypeOpInterface
   MLIRAnalysis
-  MLIRPresburger
 )

--- a/lib/Ktdp/CMakeLists.txt
+++ b/lib/Ktdp/CMakeLists.txt
@@ -17,4 +17,6 @@ add_mlir_dialect_library(MLIRKtdp
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRInferTypeOpInterface
+  MLIRAnalysis
+  MLIRPresburger
 )

--- a/lib/Ktdp/KtdpDialect.cpp
+++ b/lib/Ktdp/KtdpDialect.cpp
@@ -42,7 +42,8 @@ void KtdpDialect::initialize() {
   >();
   addTypes<
     AccessTileType,
-    RuntimeArgType
+    RuntimeArgType,
+    TileFutureType
   >();
   addAttributes<
     SpyreMemorySpaceAttr

--- a/lib/Ktdp/KtdpOps.cpp
+++ b/lib/Ktdp/KtdpOps.cpp
@@ -22,6 +22,7 @@
 #include "Ktdp/KtdpOps.hpp"
 
 #include "Ktdp/KtdpTypes.hpp"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "mlir/Analysis/FlatLinearValueConstraints.h"
 #include "mlir/Analysis/Presburger/IntegerRelation.h"
@@ -32,7 +33,6 @@
 
 using namespace mlir;
 using namespace mlir::ktdp;
-using presburger::IntegerPolyhedron;
 
 //===----------------------------------------------------------------------===//
 // ConstructAccessTilesOp
@@ -1229,38 +1229,89 @@ LogicalResult RuntimeArgExtractOp::verify() {
 
 namespace {
 
-// Build the polyhedron of tile ids selected by a parameterized tile set for a
-// single concrete group value `g`, over the tile-id dimension. `tileSet` is a
-// set `(i)[g]` (e.g. producer_tiles_per_group or consumer_tiles_per_group); we
-// materialize it as constraints and pin its lone symbol `g` to `gVal`, leaving
-// an IntegerPolyhedron over `i`.
-IntegerPolyhedron tilesForGroup(IntegerSet tileSet, int64_t gVal) {
-  FlatLinearValueConstraints cst(tileSet);
-  // The symbol introduced by the integer set is the group index `g`. Fix it to
-  // the concrete value and eliminate it, leaving the tile-id dimension(s).
-  unsigned symOffset = cst.getVarKindOffset(presburger::VarKind::Symbol);
-  cst.setAndEliminate(symOffset, {gVal});
-  return IntegerPolyhedron(cst);
-}
+// Pure-enumeration helpers for inter-tile verifiers (Option B).
+//
+// We enumerate concrete integer points rather than using Presburger set
+// operations. This keeps the code simple and removes the MLIRPresburger
+// dependency. The trade-off is that both `groups` and the tile-id range must
+// be statically bounded; unbounded cases are deferred (TODO).
+//
+// Note: a pure-Presburger approach (Option A) was also designed: disjointness
+// and subset become relation emptiness queries over (i, g) without any loop;
+// the |C|==1 mode gate requires a two-tile-variable construction. See the
+// discussion at https://github.com/torch-spyre/ktir-mlir-frontend/pull/25
+// for the full design if unbounded-groups support is ever needed.
 
-// Concrete group values that satisfy `groupsSet`, when its range is statically
-// bounded. Returns std::nullopt if unbounded (caller should defer the check).
-std::optional<SmallVector<int64_t>> boundedGroupValues(IntegerSet groupsSet) {
-  FlatLinearValueConstraints groupsCst(groupsSet);
+// Enumerate the group values in `groupsSet` (a 1D set over `g` with no
+// symbols). Returns std::nullopt when the range is not statically bounded.
+std::optional<SmallVector<int64_t>> groupValues(IntegerSet groupsSet) {
+  FlatLinearValueConstraints cst(groupsSet);
+  // getConstantBound64 returns a scalar constant lb/ub or nullopt when the
+  // bound is symbolic or absent -- exactly the bounded-vs-unbounded gate we
+  // need, with no manual constraint inspection.
   std::optional<int64_t> lo =
-      groupsCst.getConstantBound64(presburger::BoundType::LB, /*pos=*/0);
+      cst.getConstantBound64(presburger::BoundType::LB, /*pos=*/0);
   std::optional<int64_t> hi =
-      groupsCst.getConstantBound64(presburger::BoundType::UB, /*pos=*/0);
+      cst.getConstantBound64(presburger::BoundType::UB, /*pos=*/0);
   if (!lo || !hi) return std::nullopt;
   SmallVector<int64_t> vals;
   for (int64_t g = *lo; g <= *hi; ++g) {
     FlatLinearValueConstraints gCst(groupsSet);
-    IntegerPolyhedron gPoly(gCst);
-    gPoly.setAndEliminate(gPoly.getVarKindOffset(presburger::VarKind::SetDim),
-                          {g});
-    if (!gPoly.isIntegerEmpty()) vals.push_back(g);
+    gCst.setAndEliminate(gCst.getVarKindOffset(presburger::VarKind::SetDim),
+                         {g});
+    if (!gCst.isIntegerEmpty()) vals.push_back(g);
   }
   return vals;
+}
+
+// Return the set of tile ids selected by `tileSet` (a set `(i)[g]`) for a
+// concrete group value `g`. Enumerates `i` from 0 up to the static upper
+// bound on the tile-id dimension. Returns std::nullopt when that bound is not
+// statically known.
+std::optional<llvm::DenseSet<int64_t>> tilesOf(IntegerSet tileSet,
+                                               int64_t gVal) {
+  FlatLinearValueConstraints cst(tileSet);
+  // Fix the group symbol to gVal and project it out.
+  cst.setAndEliminate(cst.getVarKindOffset(presburger::VarKind::Symbol),
+                      {gVal});
+  // Upper bound on the tile-id dimension after fixing g; nullopt means the
+  // tile range is symbolic (e.g. parameterized by a runtime value) -- defer.
+  std::optional<int64_t> hi =
+      cst.getConstantBound64(presburger::BoundType::UB, /*pos=*/0);
+  if (!hi) return std::nullopt;
+  llvm::DenseSet<int64_t> out;
+  for (int64_t i = 0; i <= *hi; ++i) {
+    FlatLinearValueConstraints pt(tileSet);
+    pt.setAndEliminate(pt.getVarKindOffset(presburger::VarKind::Symbol),
+                       {gVal});
+    pt.setAndEliminate(pt.getVarKindOffset(presburger::VarKind::SetDim), {i});
+    if (!pt.isIntegerEmpty()) out.insert(i);
+  }
+  return out;
+}
+
+// Return the set of producer tiles in `depSet` (a set `(p)[c, g]`) for a
+// concrete consumer `cVal` and group `gVal`. Symbols are ordered [c, g].
+std::optional<llvm::DenseSet<int64_t>> depTilesOf(IntegerSet depSet,
+                                                   int64_t cVal,
+                                                   int64_t gVal) {
+  FlatLinearValueConstraints cst(depSet);
+  unsigned symBase = cst.getVarKindOffset(presburger::VarKind::Symbol);
+  cst.setAndEliminate(symBase, {cVal});   // fix c (first symbol)
+  cst.setAndEliminate(symBase, {gVal});   // fix g (now first remaining symbol)
+  std::optional<int64_t> hi =
+      cst.getConstantBound64(presburger::BoundType::UB, /*pos=*/0);
+  if (!hi) return std::nullopt;
+  llvm::DenseSet<int64_t> out;
+  for (int64_t p = 0; p <= *hi; ++p) {
+    FlatLinearValueConstraints pt(depSet);
+    unsigned sb = pt.getVarKindOffset(presburger::VarKind::Symbol);
+    pt.setAndEliminate(sb, {cVal});
+    pt.setAndEliminate(sb, {gVal});
+    pt.setAndEliminate(pt.getVarKindOffset(presburger::VarKind::SetDim), {p});
+    if (!pt.isIntegerEmpty()) out.insert(p);
+  }
+  return out;
 }
 
 }  // namespace
@@ -1350,22 +1401,27 @@ LogicalResult InterTileProduceOp::verify() {
                        "(the group index g)");
 
   // Disjointness invariant (§2.1): producer tile sets for distinct groups must
-  // not overlap. Enumerated check -- only when the group range is statically
-  // bounded; otherwise defer (TODO: symbolic emptiness over g1 != g2).
-  if (auto groupVals = boundedGroupValues(groupsSet)) {
-    for (size_t a = 0; a < groupVals->size(); ++a)
-      for (size_t b = a + 1; b < groupVals->size(); ++b) {
-        IntegerPolyhedron pa = tilesForGroup(producerSet, (*groupVals)[a]);
-        IntegerPolyhedron pb = tilesForGroup(producerSet, (*groupVals)[b]);
-        if (!pa.intersect(pb).isIntegerEmpty())
-          return emitOpError("producer_tiles_per_group for groups ")
-                 << (*groupVals)[a] << " and " << (*groupVals)[b]
-                 << " are not disjoint";
-      }
+  // not overlap. Enumeration check -- requires statically bounded groups and
+  // tile-id range; deferred otherwise.
+  if (auto groupVals = groupValues(groupsSet)) {
+    SmallVector<llvm::DenseSet<int64_t>> tileSets;
+    for (int64_t g : *groupVals) {
+      auto ts = tilesOf(producerSet, g);
+      if (!ts) break;  // tile bound not static for this g -- skip
+      tileSets.push_back(std::move(*ts));
+    }
+    if (tileSets.size() == groupVals->size()) {
+      for (size_t a = 0; a < tileSets.size(); ++a)
+        for (size_t b = a + 1; b < tileSets.size(); ++b)
+          for (int64_t tile : tileSets[a])
+            if (tileSets[b].count(tile))
+              return emitOpError("producer_tiles_per_group for groups ")
+                     << (*groupVals)[a] << " and " << (*groupVals)[b]
+                     << " are not disjoint";
+    }
   }
-  // else: unbounded group range -- defer to a future symbolic check.
+  // else: unbounded -- defer to a future symbolic check.
 
-  // TODO(inter-tile): symbolic disjointness check for unbounded group ranges.
   return success();
 }
 
@@ -1571,21 +1627,24 @@ LogicalResult InterTileReduceOp::verify() {
       return emitOpError("`consumer_tiles_per_group` must have exactly one "
                          "symbol (the group index g)");
 
-    if (auto groupVals = boundedGroupValues(groupsSet)) {
+    if (auto groupVals = groupValues(groupsSet)) {
       for (int64_t g : *groupVals) {
-        IntegerPolyhedron c = tilesForGroup(consumerSet, g);
-        IntegerPolyhedron p = tilesForGroup(producerSet, g);
+        auto cOpt = tilesOf(consumerSet, g);
+        auto pOpt = tilesOf(producerSet, g);
+        if (!cOpt || !pOpt) continue;  // tile bound not static -- defer
+        const auto& c = *cOpt;
+        const auto& p = *pOpt;
         // Mandated: every consumer must have produced (C subset of P). A
         // consumer outside the producer set is open question Q1 -- unsupported.
-        if (!c.isSubsetOf(p))
-          return emitOpError("consumer_tiles_per_group for group ")
-                 << g << " is not a subset of producer_tiles_per_group "
-                 << "(a consumer tile that did not produce is unsupported; "
-                 << "see open question Q1)";
+        for (int64_t tile : c)
+          if (!p.count(tile))
+            return emitOpError("consumer_tiles_per_group for group ")
+                   << g << " is not a subset of producer_tiles_per_group "
+                   << "(a consumer tile that did not produce is unsupported; "
+                   << "see open question Q1)";
         // Accept all-reduce (C == P) or reduce-to-one (|C| == 1).
-        if (c.isEqual(p)) continue;
-        std::optional<llvm::DynamicAPInt> vol = c.computeVolume();
-        if (vol && *vol == llvm::DynamicAPInt(1)) continue;
+        if (c == p) continue;
+        if (c.size() == 1) continue;
         return emitOpError("consumer_tiles_per_group for group ")
                << g << " is a strict subset of producer_tiles_per_group with "
                << "more than one tile (reduce-to-subset is unsupported; only "
@@ -1595,8 +1654,56 @@ LogicalResult InterTileReduceOp::verify() {
     // else: unbounded group range -- defer to a future symbolic check.
   }
 
-  // TODO(inter-tile): `groups` matches the producing op; subset/coverage of
-  // producer_dependency_per_consumer; symbolic (unbounded-groups) variants.
+  // Check 4: `groups` on reduce must match `groups` on the paired produce.
+  if (produceOp) {
+    if (getGroups().getValue() != produceOp.getGroups().getValue())
+      return emitOpError("`groups` does not match the paired "
+                         "`inter_tile_produce`");
+  }
+
+  // Check 5: producer_dependency_per_consumer (when present).
+  //   (a) Subset: every p in D(c, g) must be in P(g).
+  //   (b) Coverage: every p in P(g) must appear in D(c, g) for some c in C(g).
+  if (produceOp) {
+    if (auto depAttr = getProducerDependencyPerConsumerAttr()) {
+      IntegerSet depSet = depAttr.getValue();
+      if (depSet.getNumSymbols() != 2)
+        return emitOpError("`producer_dependency_per_consumer` must have "
+                           "exactly two symbols (c, g)");
+      IntegerSet groupsSet = getGroups().getValue();
+      IntegerSet consumerSet = getConsumerTilesPerGroup().getValue();
+      IntegerSet producerSet = produceOp.getProducerTilesPerGroup().getValue();
+      if (auto groupVals = groupValues(groupsSet)) {
+        for (int64_t g : *groupVals) {
+          auto cOpt = tilesOf(consumerSet, g);
+          auto pOpt = tilesOf(producerSet, g);
+          if (!cOpt || !pOpt) continue;  // defer if tile bound not static
+          llvm::DenseSet<int64_t> covered;
+          for (int64_t c : *cOpt) {
+            auto dOpt = depTilesOf(depSet, c, g);
+            if (!dOpt) continue;
+            for (int64_t p : *dOpt) {
+              // (a) subset check
+              if (!pOpt->count(p))
+                return emitOpError(
+                           "producer_dependency_per_consumer for consumer ")
+                       << c << " group " << g << " references producer tile "
+                       << p << " which is not in producer_tiles_per_group";
+              covered.insert(p);
+            }
+          }
+          // (b) coverage check
+          for (int64_t p : *pOpt)
+            if (!covered.count(p))
+              return emitOpError(
+                         "producer_dependency_per_consumer for group ")
+                     << g << " does not cover producer tile " << p
+                     << " (no consumer has it as a dependency)";
+        }
+      }
+    }
+  }
+
   return success();
 }
 

--- a/lib/Ktdp/KtdpOps.cpp
+++ b/lib/Ktdp/KtdpOps.cpp
@@ -1229,17 +1229,38 @@ LogicalResult RuntimeArgExtractOp::verify() {
 
 namespace {
 
-// Build the polyhedron of producer tile ids for a single concrete group value
-// `g`, over the tile-id dimension. `producerSet` is the parameterized set
-// `(i)[g]`; we materialize it as constraints and pin its lone symbol `g` to
-// `gVal`, leaving an IntegerPolyhedron over `i`.
-IntegerPolyhedron producerTilesForGroup(IntegerSet producerSet, int64_t gVal) {
-  FlatLinearValueConstraints cst(producerSet);
+// Build the polyhedron of tile ids selected by a parameterized tile set for a
+// single concrete group value `g`, over the tile-id dimension. `tileSet` is a
+// set `(i)[g]` (e.g. producer_tiles_per_group or consumer_tiles_per_group); we
+// materialize it as constraints and pin its lone symbol `g` to `gVal`, leaving
+// an IntegerPolyhedron over `i`.
+IntegerPolyhedron tilesForGroup(IntegerSet tileSet, int64_t gVal) {
+  FlatLinearValueConstraints cst(tileSet);
   // The symbol introduced by the integer set is the group index `g`. Fix it to
   // the concrete value and eliminate it, leaving the tile-id dimension(s).
   unsigned symOffset = cst.getVarKindOffset(presburger::VarKind::Symbol);
   cst.setAndEliminate(symOffset, {gVal});
   return IntegerPolyhedron(cst);
+}
+
+// Concrete group values that satisfy `groupsSet`, when its range is statically
+// bounded. Returns std::nullopt if unbounded (caller should defer the check).
+std::optional<SmallVector<int64_t>> boundedGroupValues(IntegerSet groupsSet) {
+  FlatLinearValueConstraints groupsCst(groupsSet);
+  std::optional<int64_t> lo =
+      groupsCst.getConstantBound64(presburger::BoundType::LB, /*pos=*/0);
+  std::optional<int64_t> hi =
+      groupsCst.getConstantBound64(presburger::BoundType::UB, /*pos=*/0);
+  if (!lo || !hi) return std::nullopt;
+  SmallVector<int64_t> vals;
+  for (int64_t g = *lo; g <= *hi; ++g) {
+    FlatLinearValueConstraints gCst(groupsSet);
+    IntegerPolyhedron gPoly(gCst);
+    gPoly.setAndEliminate(gPoly.getVarKindOffset(presburger::VarKind::SetDim),
+                          {g});
+    if (!gPoly.isIntegerEmpty()) vals.push_back(g);
+  }
+  return vals;
 }
 
 }  // namespace
@@ -1331,35 +1352,18 @@ LogicalResult InterTileProduceOp::verify() {
   // Disjointness invariant (§2.1): producer tile sets for distinct groups must
   // not overlap. Enumerated check -- only when the group range is statically
   // bounded; otherwise defer (TODO: symbolic emptiness over g1 != g2).
-  {
-    FlatLinearValueConstraints groupsCst(groupsSet);
-    std::optional<int64_t> lo =
-        groupsCst.getConstantBound64(presburger::BoundType::LB, /*pos=*/0);
-    std::optional<int64_t> hi =
-        groupsCst.getConstantBound64(presburger::BoundType::UB, /*pos=*/0);
-    if (lo && hi) {
-      // Concrete group values in `groups`. The [lo, hi] box may be looser than
-      // the set (e.g. strided ranges), so keep only g actually in `groups`.
-      SmallVector<int64_t> groupVals;
-      for (int64_t g = *lo; g <= *hi; ++g) {
-        FlatLinearValueConstraints gCst(groupsSet);
-        IntegerPolyhedron gPoly(gCst);
-        gPoly.setAndEliminate(gPoly.getVarKindOffset(presburger::VarKind::SetDim),
-                              {g});
-        if (!gPoly.isIntegerEmpty()) groupVals.push_back(g);
+  if (auto groupVals = boundedGroupValues(groupsSet)) {
+    for (size_t a = 0; a < groupVals->size(); ++a)
+      for (size_t b = a + 1; b < groupVals->size(); ++b) {
+        IntegerPolyhedron pa = tilesForGroup(producerSet, (*groupVals)[a]);
+        IntegerPolyhedron pb = tilesForGroup(producerSet, (*groupVals)[b]);
+        if (!pa.intersect(pb).isIntegerEmpty())
+          return emitOpError("producer_tiles_per_group for groups ")
+                 << (*groupVals)[a] << " and " << (*groupVals)[b]
+                 << " are not disjoint";
       }
-      for (size_t a = 0; a < groupVals.size(); ++a)
-        for (size_t b = a + 1; b < groupVals.size(); ++b) {
-          IntegerPolyhedron pa = producerTilesForGroup(producerSet, groupVals[a]);
-          IntegerPolyhedron pb = producerTilesForGroup(producerSet, groupVals[b]);
-          if (!pa.intersect(pb).isIntegerEmpty())
-            return emitOpError("producer_tiles_per_group for groups ")
-                   << groupVals[a] << " and " << groupVals[b]
-                   << " are not disjoint";
-        }
-    }
-    // else: unbounded group range -- defer to a future symbolic check.
   }
+  // else: unbounded group range -- defer to a future symbolic check.
 
   // TODO(inter-tile): symbolic disjointness check for unbounded group ranges.
   return success();
@@ -1544,8 +1548,55 @@ LogicalResult InterTileReduceOp::verify() {
              << " with a single unit within-group tile axis collapsed";
   }
 
-  // TODO(inter-tile): polyhedral checks via Presburger -- `groups` matches the
-  // producing op; subset/coverage of producer_dependency_per_consumer.
+  // Consumer-vs-producer relation (§4.1, §4.5, open question Q1).
+  //
+  // The producing op carries `producer_tiles_per_group`; reach it through the
+  // future's def. The future single-use rule (verified on the produce op)
+  // means a well-formed future is defined by exactly one inter_tile_produce;
+  // if we cannot see it (e.g. block/function argument) we cannot compare sets,
+  // so we defer.
+  //
+  // Supported modes (per group g, with P = producer set, C = consumer set):
+  //   * all-reduce:     C == P
+  //   * reduce-to-one:  |C| == 1 and C subset of P
+  // Everything else is rejected as UNSUPPORTED (not a spec violation -- the
+  // spec also permits reduce-to-subset 1<|C|<|P|, and leaves C-not-subset-of-P
+  // open as Q1 -- but this implementation supports only the two modes above).
+  auto produceOp = getFuture().getDefiningOp<InterTileProduceOp>();
+  if (produceOp) {
+    IntegerSet groupsSet = getGroups().getValue();
+    IntegerSet consumerSet = getConsumerTilesPerGroup().getValue();
+    IntegerSet producerSet = produceOp.getProducerTilesPerGroup().getValue();
+    if (consumerSet.getNumSymbols() != 1)
+      return emitOpError("`consumer_tiles_per_group` must have exactly one "
+                         "symbol (the group index g)");
+
+    if (auto groupVals = boundedGroupValues(groupsSet)) {
+      for (int64_t g : *groupVals) {
+        IntegerPolyhedron c = tilesForGroup(consumerSet, g);
+        IntegerPolyhedron p = tilesForGroup(producerSet, g);
+        // Mandated: every consumer must have produced (C subset of P). A
+        // consumer outside the producer set is open question Q1 -- unsupported.
+        if (!c.isSubsetOf(p))
+          return emitOpError("consumer_tiles_per_group for group ")
+                 << g << " is not a subset of producer_tiles_per_group "
+                 << "(a consumer tile that did not produce is unsupported; "
+                 << "see open question Q1)";
+        // Accept all-reduce (C == P) or reduce-to-one (|C| == 1).
+        if (c.isEqual(p)) continue;
+        std::optional<llvm::DynamicAPInt> vol = c.computeVolume();
+        if (vol && *vol == llvm::DynamicAPInt(1)) continue;
+        return emitOpError("consumer_tiles_per_group for group ")
+               << g << " is a strict subset of producer_tiles_per_group with "
+               << "more than one tile (reduce-to-subset is unsupported; only "
+               << "all-reduce and reduce-to-one are supported)";
+      }
+    }
+    // else: unbounded group range -- defer to a future symbolic check.
+  }
+
+  // TODO(inter-tile): `groups` matches the producing op; subset/coverage of
+  // producer_dependency_per_consumer; symbolic (unbounded-groups) variants.
   return success();
 }
 

--- a/lib/Ktdp/KtdpOps.cpp
+++ b/lib/Ktdp/KtdpOps.cpp
@@ -1220,6 +1220,276 @@ LogicalResult RuntimeArgExtractOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// InterTileProduceOp
+//===----------------------------------------------------------------------===//
+
+// Syntax:
+//   ktdp.inter_tile_produce
+//       producer_tiles_per_group = <set>, groups = <set>
+//       : T_p_1, ..., T_p_N -> !ktdp.tile_future<T_p_1, ..., T_p_N>
+//       { ^bb0(%gid: index): ktdp.yield_partial ... }
+ParseResult InterTileProduceOp::parse(OpAsmParser& parser,
+                                      OperationState& result) {
+  IntegerSetAttr producerSet, groupsSet;
+  if (parser.parseKeyword("producer_tiles_per_group") || parser.parseEqual() ||
+      parser.parseAttribute(producerSet, "producer_tiles_per_group",
+                            result.attributes) ||
+      parser.parseComma() || parser.parseKeyword("groups") ||
+      parser.parseEqual() ||
+      parser.parseAttribute(groupsSet, "groups", result.attributes))
+    return failure();
+
+  if (parser.parseOptionalAttrDict(result.attributes)) return failure();
+
+  // Partial types ... -> future type.
+  SmallVector<Type> partialTypes;
+  Type futureType;
+  if (parser.parseColonTypeList(partialTypes) || parser.parseArrow() ||
+      parser.parseType(futureType))
+    return failure();
+  result.addTypes(futureType);
+
+  // Producer region.
+  Region* body = result.addRegion();
+  if (parser.parseRegion(*body, /*arguments=*/{}, /*enableNameShadowing=*/false))
+    return failure();
+  return success();
+}
+
+void InterTileProduceOp::print(OpAsmPrinter& p) {
+  p << " producer_tiles_per_group = " << getProducerTilesPerGroupAttr()
+    << ", groups = " << getGroupsAttr();
+  p.printOptionalAttrDict((*this)->getAttrs(),
+                          /*elidedAttrs=*/{"producer_tiles_per_group", "groups"});
+  p << " : ";
+  llvm::interleaveComma(getPartialTypes(), p);
+  p << " -> " << getFuture().getType() << ' ';
+  p.printRegion(getBody(), /*printEntryBlockArgs=*/true,
+                /*printBlockTerminators=*/true);
+}
+
+LogicalResult InterTileProduceOp::verify() {
+  auto futureType = cast<TileFutureType>(getFuture().getType());
+  ArrayRef<Type> partials = futureType.getPartialTypes();
+
+  // Single-use invariant (§2.3): exactly one delivery op consumes the future.
+  if (!getFuture().hasOneUse() && !getFuture().use_empty())
+    return emitOpError("future result must have exactly one use (the single "
+                       "delivery op that consumes it)");
+
+  // Producer region: one block, single `index` group-id argument.
+  Block& block = getBody().front();
+  if (block.getNumArguments() != 1 ||
+      !block.getArgument(0).getType().isIndex())
+    return emitOpError(
+        "producer region must take a single `index` group-id argument");
+
+  // Terminator yields one value per partial role, matching the future types.
+  auto yield = cast<YieldPartialOp>(block.getTerminator());
+  if (yield.getValues().size() != partials.size())
+    return emitOpError("yield_partial yields ")
+           << yield.getValues().size() << " values but the future carries "
+           << partials.size() << " partial type(s)";
+  for (auto [i, val] : llvm::enumerate(yield.getValues()))
+    if (val.getType() != partials[i])
+      return emitOpError("yield_partial operand #")
+             << i << " type " << val.getType()
+             << " does not match future partial type " << partials[i];
+
+  // The producer set's symbol must be the group index `g`; groups set has none.
+  if (getGroups().getValue().getNumSymbols() != 0)
+    return emitOpError("`groups` integer set must not have symbols");
+
+  // TODO(inter-tile): polyhedral checks via Presburger -- disjointness of
+  // producer_tiles_per_group across distinct group indices in `groups`.
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// InterTileReduceOp
+//===----------------------------------------------------------------------===//
+
+// Syntax:
+//   ktdp.inter_tile_reduce(%future)
+//       consumer_tiles_per_group = <set>, groups = <set>,
+//       [producer_dependency_per_consumer = <set>,]
+//       identity(%id_1 : T_p_1, ..., %id_N : T_p_N)
+//       : !ktdp.tile_future<...> -> T_r_1, ..., T_r_N
+//       { ^bb0(...2N args...): ktdp.yield_reduced ... }
+ParseResult InterTileReduceOp::parse(OpAsmParser& parser,
+                                     OperationState& result) {
+  OpAsmParser::UnresolvedOperand future;
+  if (parser.parseLParen() || parser.parseOperand(future) ||
+      parser.parseRParen())
+    return failure();
+
+  IntegerSetAttr consumerSet, groupsSet;
+  if (parser.parseKeyword("consumer_tiles_per_group") || parser.parseEqual() ||
+      parser.parseAttribute(consumerSet, "consumer_tiles_per_group",
+                            result.attributes) ||
+      parser.parseComma() || parser.parseKeyword("groups") ||
+      parser.parseEqual() ||
+      parser.parseAttribute(groupsSet, "groups", result.attributes))
+    return failure();
+
+  // Optional producer_dependency_per_consumer.
+  if (succeeded(parser.parseOptionalComma())) {
+    // Either the optional dependency set or directly the identity list.
+    if (succeeded(
+            parser.parseOptionalKeyword("producer_dependency_per_consumer"))) {
+      IntegerSetAttr depSet;
+      if (parser.parseEqual() ||
+          parser.parseAttribute(depSet, "producer_dependency_per_consumer",
+                                result.attributes) ||
+          parser.parseComma())
+        return failure();
+    }
+  }
+
+  // identity(%id : T, ...)
+  SmallVector<OpAsmParser::UnresolvedOperand> identityOperands;
+  SmallVector<Type> identityTypes;
+  if (parser.parseKeyword("identity") ||
+      parser.parseCommaSeparatedList(AsmParser::Delimiter::Paren, [&]() {
+        OpAsmParser::UnresolvedOperand op;
+        Type t;
+        if (parser.parseOperand(op) || parser.parseColonType(t)) return failure();
+        identityOperands.push_back(op);
+        identityTypes.push_back(t);
+        return success();
+      }))
+    return failure();
+
+  if (parser.parseOptionalAttrDict(result.attributes)) return failure();
+
+  Type futureType;
+  SmallVector<Type> resultTypes;
+  if (parser.parseColonType(futureType) || parser.parseArrow() ||
+      parser.parseTypeList(resultTypes))
+    return failure();
+
+  if (parser.resolveOperand(future, futureType, result.operands) ||
+      parser.resolveOperands(identityOperands, identityTypes,
+                             parser.getNameLoc(), result.operands))
+    return failure();
+  result.addTypes(resultTypes);
+
+  // Operand segment sizes: 1 future + N identities.
+  result.addAttribute(
+      "operandSegmentSizes",
+      parser.getBuilder().getDenseI32ArrayAttr(
+          {1, static_cast<int32_t>(identityOperands.size())}));
+
+  Region* combiner = result.addRegion();
+  if (parser.parseRegion(*combiner, /*arguments=*/{}))
+    return failure();
+  return success();
+}
+
+void InterTileReduceOp::print(OpAsmPrinter& p) {
+  p << '(' << getFuture() << ") consumer_tiles_per_group = "
+    << getConsumerTilesPerGroupAttr() << ", groups = " << getGroupsAttr();
+  if (auto dep = getProducerDependencyPerConsumerAttr())
+    p << ", producer_dependency_per_consumer = " << dep;
+  p << ", identity(";
+  llvm::interleaveComma(getIdentity(), p, [&](Value v) {
+    p << v << " : " << v.getType();
+  });
+  p << ')';
+  p.printOptionalAttrDict(
+      (*this)->getAttrs(),
+      /*elidedAttrs=*/{"consumer_tiles_per_group", "groups",
+                       "producer_dependency_per_consumer",
+                       "operandSegmentSizes"});
+  p << " : " << getFuture().getType() << " -> ";
+  llvm::interleaveComma(getResultTypes(), p);
+  p << ' ';
+  p.printRegion(getCombiner(), /*printEntryBlockArgs=*/true,
+                /*printBlockTerminators=*/true);
+}
+
+LogicalResult InterTileReduceOp::verify() {
+  ArrayRef<Type> partials = getPartialTypes();
+  size_t n = partials.size();
+
+  // identity: one per role, matching the partial type T_p_i.
+  if (getIdentity().size() != n)
+    return emitOpError("expected ")
+           << n << " identity operand(s), got " << getIdentity().size();
+  for (auto [i, id] : llvm::enumerate(getIdentity()))
+    if (id.getType() != partials[i])
+      return emitOpError("identity #")
+             << i << " type " << id.getType()
+             << " must match future partial type " << partials[i];
+
+  // results: one per role.
+  if (getResults().size() != n)
+    return emitOpError("expected ")
+           << n << " result(s), got " << getResults().size();
+
+  // Reducer region: 2N args (lhs_1..lhs_N, rhs_1..rhs_N) each of type T_p_i.
+  Block& block = getCombiner().front();
+  if (block.getNumArguments() != 2 * n)
+    return emitOpError("reducer region must take 2*")
+           << n << " arguments, got " << block.getNumArguments();
+  for (size_t i = 0; i < n; ++i) {
+    if (block.getArgument(i).getType() != partials[i] ||
+        block.getArgument(n + i).getType() != partials[i])
+      return emitOpError("reducer region argument pair #")
+             << i << " must both have partial type " << partials[i];
+  }
+
+  // Terminator yields N values of the partial types T_p_i.
+  auto yield = cast<YieldReducedOp>(block.getTerminator());
+  if (yield.getValues().size() != n)
+    return emitOpError("yield_reduced yields ")
+           << yield.getValues().size() << " values but expected " << n;
+  for (auto [i, val] : llvm::enumerate(yield.getValues()))
+    if (val.getType() != partials[i])
+      return emitOpError("yield_reduced operand #")
+             << i << " type " << val.getType()
+             << " must match partial type " << partials[i];
+
+  // Collapsed-axis shape rule: each result T_r_i is T_p_i with one
+  // within-group tile axis removed. Structural check: result rank is one less
+  // than the partial rank and the surviving dims are a subsequence of the
+  // partial dims (the removed axis must be a unit dimension).
+  for (size_t i = 0; i < n; ++i) {
+    auto pTy = cast<RankedTensorType>(partials[i]);
+    auto rTy = dyn_cast<RankedTensorType>(getResult(i).getType());
+    if (!rTy)
+      return emitOpError("result #") << i << " must be a ranked tensor";
+    if (rTy.getRank() != pTy.getRank() - 1)
+      return emitOpError("result #")
+             << i << " rank (" << rTy.getRank()
+             << ") must be one less than partial rank (" << pTy.getRank()
+             << "); exactly one within-group tile axis is collapsed";
+    // The collapsed axis must be a unit dim; the remaining dims must match the
+    // result dims in order.
+    ArrayRef<int64_t> pShape = pTy.getShape();
+    ArrayRef<int64_t> rShape = rTy.getShape();
+    bool found = false;
+    for (int64_t axis = 0; axis < pTy.getRank(); ++axis) {
+      if (pShape[axis] != 1) continue;
+      SmallVector<int64_t> collapsed(pShape.begin(), pShape.end());
+      collapsed.erase(collapsed.begin() + axis);
+      if (ArrayRef<int64_t>(collapsed) == rShape) {
+        found = true;
+        break;
+      }
+    }
+    if (!found)
+      return emitOpError("result #")
+             << i << " shape does not match partial #" << i
+             << " with a single unit within-group tile axis collapsed";
+  }
+
+  // TODO(inter-tile): polyhedral checks via Presburger -- `groups` matches the
+  // producing op; subset/coverage of producer_dependency_per_consumer.
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen'd op method definitions
 //===----------------------------------------------------------------------===//
 #define GET_OP_CLASSES

--- a/lib/Ktdp/KtdpOps.cpp
+++ b/lib/Ktdp/KtdpOps.cpp
@@ -23,12 +23,16 @@
 
 #include "Ktdp/KtdpTypes.hpp"
 #include "llvm/ADT/TypeSwitch.h"
+#include "mlir/Analysis/FlatLinearValueConstraints.h"
+#include "mlir/Analysis/Presburger/IntegerRelation.h"
 #include "mlir/IR/DialectImplementation.h"
+#include "mlir/IR/IntegerSet.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
 
 using namespace mlir;
 using namespace mlir::ktdp;
+using presburger::IntegerPolyhedron;
 
 //===----------------------------------------------------------------------===//
 // ConstructAccessTilesOp
@@ -1223,6 +1227,23 @@ LogicalResult RuntimeArgExtractOp::verify() {
 // InterTileProduceOp
 //===----------------------------------------------------------------------===//
 
+namespace {
+
+// Build the polyhedron of producer tile ids for a single concrete group value
+// `g`, over the tile-id dimension. `producerSet` is the parameterized set
+// `(i)[g]`; we materialize it as constraints and pin its lone symbol `g` to
+// `gVal`, leaving an IntegerPolyhedron over `i`.
+IntegerPolyhedron producerTilesForGroup(IntegerSet producerSet, int64_t gVal) {
+  FlatLinearValueConstraints cst(producerSet);
+  // The symbol introduced by the integer set is the group index `g`. Fix it to
+  // the concrete value and eliminate it, leaving the tile-id dimension(s).
+  unsigned symOffset = cst.getVarKindOffset(presburger::VarKind::Symbol);
+  cst.setAndEliminate(symOffset, {gVal});
+  return IntegerPolyhedron(cst);
+}
+
+}  // namespace
+
 // Syntax:
 //   ktdp.inter_tile_produce
 //       producer_tiles_per_group = <set>, groups = <set>
@@ -1297,11 +1318,50 @@ LogicalResult InterTileProduceOp::verify() {
              << " does not match future partial type " << partials[i];
 
   // The producer set's symbol must be the group index `g`; groups set has none.
-  if (getGroups().getValue().getNumSymbols() != 0)
+  IntegerSet groupsSet = getGroups().getValue();
+  IntegerSet producerSet = getProducerTilesPerGroup().getValue();
+  if (groupsSet.getNumSymbols() != 0)
     return emitOpError("`groups` integer set must not have symbols");
+  if (groupsSet.getNumDims() != 1)
+    return emitOpError("`groups` integer set must have a single dimension (g)");
+  if (producerSet.getNumSymbols() != 1)
+    return emitOpError("`producer_tiles_per_group` must have exactly one symbol "
+                       "(the group index g)");
 
-  // TODO(inter-tile): polyhedral checks via Presburger -- disjointness of
-  // producer_tiles_per_group across distinct group indices in `groups`.
+  // Disjointness invariant (§2.1): producer tile sets for distinct groups must
+  // not overlap. Enumerated check -- only when the group range is statically
+  // bounded; otherwise defer (TODO: symbolic emptiness over g1 != g2).
+  {
+    FlatLinearValueConstraints groupsCst(groupsSet);
+    std::optional<int64_t> lo =
+        groupsCst.getConstantBound64(presburger::BoundType::LB, /*pos=*/0);
+    std::optional<int64_t> hi =
+        groupsCst.getConstantBound64(presburger::BoundType::UB, /*pos=*/0);
+    if (lo && hi) {
+      // Concrete group values in `groups`. The [lo, hi] box may be looser than
+      // the set (e.g. strided ranges), so keep only g actually in `groups`.
+      SmallVector<int64_t> groupVals;
+      for (int64_t g = *lo; g <= *hi; ++g) {
+        FlatLinearValueConstraints gCst(groupsSet);
+        IntegerPolyhedron gPoly(gCst);
+        gPoly.setAndEliminate(gPoly.getVarKindOffset(presburger::VarKind::SetDim),
+                              {g});
+        if (!gPoly.isIntegerEmpty()) groupVals.push_back(g);
+      }
+      for (size_t a = 0; a < groupVals.size(); ++a)
+        for (size_t b = a + 1; b < groupVals.size(); ++b) {
+          IntegerPolyhedron pa = producerTilesForGroup(producerSet, groupVals[a]);
+          IntegerPolyhedron pb = producerTilesForGroup(producerSet, groupVals[b]);
+          if (!pa.intersect(pb).isIntegerEmpty())
+            return emitOpError("producer_tiles_per_group for groups ")
+                   << groupVals[a] << " and " << groupVals[b]
+                   << " are not disjoint";
+        }
+    }
+    // else: unbounded group range -- defer to a future symbolic check.
+  }
+
+  // TODO(inter-tile): symbolic disjointness check for unbounded group ranges.
   return success();
 }
 

--- a/lib/Ktdp/KtdpTypes.cpp
+++ b/lib/Ktdp/KtdpTypes.cpp
@@ -151,3 +151,45 @@ Type RuntimeArgType::parse(AsmParser &parser) {
       [&] { return parser.emitError(parser.getCurrentLocation()); },
       underlyingType, granularity, upperbound);
 }
+
+//===----------------------------------------------------------------------===//
+// TileFutureType
+//===----------------------------------------------------------------------===//
+
+LogicalResult TileFutureType::verify(
+    function_ref<InFlightDiagnostic()> emitError, ArrayRef<Type> partialTypes) {
+  if (partialTypes.empty())
+    return emitError() << "tile_future must carry at least one partial type";
+
+  for (Type t : partialTypes) {
+    if (!mlir::isa<RankedTensorType>(t))
+      return emitError() << "tile_future partial type must be a ranked tensor, "
+                            "but got: "
+                         << t;
+  }
+
+  return success();
+}
+
+void TileFutureType::print(AsmPrinter &printer) const {
+  printer << "<";
+  llvm::interleaveComma(getPartialTypes(), printer);
+  printer << ">";
+}
+
+Type TileFutureType::parse(AsmParser &parser) {
+  if (parser.parseLess()) return Type();
+
+  SmallVector<Type, 2> partialTypes;
+  do {
+    Type t;
+    if (parser.parseType(t)) return Type();
+    partialTypes.push_back(t);
+  } while (succeeded(parser.parseOptionalComma()));
+
+  if (parser.parseGreater()) return Type();
+
+  return TileFutureType::getChecked(
+      [&] { return parser.emitError(parser.getCurrentLocation()); },
+      partialTypes);
+}

--- a/test/Ktdp/inter-tile-reduce-invalid.mlir
+++ b/test/Ktdp/inter-tile-reduce-invalid.mlir
@@ -1,0 +1,84 @@
+// RUN: ktir-opt "%s" -split-input-file -verify-diagnostics
+
+// Note: -split-input-file parses each chunk independently, so affine-set
+// aliases are declared per chunk.
+
+// -----
+// yield_partial arity must match the future's partial count.
+#g  = affine_set<(i)[g] : (i - 4*g >= 0, -i + 4*g + 3 >= 0)>
+#ag = affine_set<(g) : (g == 0)>
+func.func @bad_produce_arity(%p: tensor<1x64xf16>) {
+  // expected-error @below {{yield_partial yields 1 values but the future carries 2 partial type(s)}}
+  %f = ktdp.inter_tile_produce producer_tiles_per_group = #g, groups = #ag
+      : tensor<1x64xf16> -> !ktdp.tile_future<tensor<1x64xf16>, tensor<1x64xf16>>
+  { ^bb0(%gid: index): ktdp.yield_partial %p : tensor<1x64xf16> }
+  return
+}
+
+// -----
+// future result must have exactly one use.
+#g  = affine_set<(i)[g] : (i - 4*g >= 0, -i + 4*g + 3 >= 0)>
+#ag = affine_set<(g) : (g == 0)>
+func.func @bad_multiple_uses(%p: tensor<1x64xf16>, %id: tensor<1x64xf16>) {
+  // expected-error @below {{future result must have exactly one use}}
+  %f = ktdp.inter_tile_produce producer_tiles_per_group = #g, groups = #ag
+      : tensor<1x64xf16> -> !ktdp.tile_future<tensor<1x64xf16>>
+  { ^bb0(%gid: index): ktdp.yield_partial %p : tensor<1x64xf16> }
+  %r0 = ktdp.inter_tile_reduce(%f) consumer_tiles_per_group = #g, groups = #ag, identity(%id : tensor<1x64xf16>)
+      : !ktdp.tile_future<tensor<1x64xf16>> -> tensor<64xf16>
+  { ^bb0(%l: tensor<1x64xf16>, %rr: tensor<1x64xf16>): ktdp.yield_reduced %l : tensor<1x64xf16> }
+  %r1 = ktdp.inter_tile_reduce(%f) consumer_tiles_per_group = #g, groups = #ag, identity(%id : tensor<1x64xf16>)
+      : !ktdp.tile_future<tensor<1x64xf16>> -> tensor<64xf16>
+  { ^bb0(%l: tensor<1x64xf16>, %rr: tensor<1x64xf16>): ktdp.yield_reduced %l : tensor<1x64xf16> }
+  return
+}
+
+// -----
+// identity type must match the partial type.
+#g  = affine_set<(i)[g] : (i - 4*g >= 0, -i + 4*g + 3 >= 0)>
+#ag = affine_set<(g) : (g == 0)>
+func.func @bad_identity_type(%p: tensor<1x64xf16>, %id: tensor<2x64xf16>) -> tensor<64xf16> {
+  %f = ktdp.inter_tile_produce producer_tiles_per_group = #g, groups = #ag
+      : tensor<1x64xf16> -> !ktdp.tile_future<tensor<1x64xf16>>
+  { ^bb0(%gid: index): ktdp.yield_partial %p : tensor<1x64xf16> }
+  // expected-error @below {{identity #0 type 'tensor<2x64xf16>' must match future partial type 'tensor<1x64xf16>'}}
+  %r = ktdp.inter_tile_reduce(%f) consumer_tiles_per_group = #g, groups = #ag, identity(%id : tensor<2x64xf16>)
+      : !ktdp.tile_future<tensor<1x64xf16>> -> tensor<64xf16>
+  { ^bb0(%l: tensor<1x64xf16>, %rr: tensor<1x64xf16>): ktdp.yield_reduced %l : tensor<1x64xf16> }
+  return %r : tensor<64xf16>
+}
+
+// -----
+// result rank must be exactly one less than the partial rank.
+#g  = affine_set<(i)[g] : (i - 4*g >= 0, -i + 4*g + 3 >= 0)>
+#ag = affine_set<(g) : (g == 0)>
+func.func @bad_collapse_rank(%p: tensor<1x64xf16>, %id: tensor<1x64xf16>) -> tensor<1x64xf16> {
+  %f = ktdp.inter_tile_produce producer_tiles_per_group = #g, groups = #ag
+      : tensor<1x64xf16> -> !ktdp.tile_future<tensor<1x64xf16>>
+  { ^bb0(%gid: index): ktdp.yield_partial %p : tensor<1x64xf16> }
+  // expected-error @below {{result #0 rank (2) must be one less than partial rank (2)}}
+  %r = ktdp.inter_tile_reduce(%f) consumer_tiles_per_group = #g, groups = #ag, identity(%id : tensor<1x64xf16>)
+      : !ktdp.tile_future<tensor<1x64xf16>> -> tensor<1x64xf16>
+  { ^bb0(%l: tensor<1x64xf16>, %rr: tensor<1x64xf16>): ktdp.yield_reduced %l : tensor<1x64xf16> }
+  return %r : tensor<1x64xf16>
+}
+
+// -----
+// collapsed axis must be a unit dimension (96 cannot collapse to 64).
+#g  = affine_set<(i)[g] : (i - 4*g >= 0, -i + 4*g + 3 >= 0)>
+#ag = affine_set<(g) : (g == 0)>
+func.func @bad_collapse_nonunit(%p: tensor<96x64xf16>, %id: tensor<96x64xf16>) -> tensor<64xf16> {
+  %f = ktdp.inter_tile_produce producer_tiles_per_group = #g, groups = #ag
+      : tensor<96x64xf16> -> !ktdp.tile_future<tensor<96x64xf16>>
+  { ^bb0(%gid: index): ktdp.yield_partial %p : tensor<96x64xf16> }
+  // expected-error @below {{result #0 shape does not match partial #0 with a single unit within-group tile axis collapsed}}
+  %r = ktdp.inter_tile_reduce(%f) consumer_tiles_per_group = #g, groups = #ag, identity(%id : tensor<96x64xf16>)
+      : !ktdp.tile_future<tensor<96x64xf16>> -> tensor<64xf16>
+  { ^bb0(%l: tensor<96x64xf16>, %rr: tensor<96x64xf16>): ktdp.yield_reduced %l : tensor<96x64xf16> }
+  return %r : tensor<64xf16>
+}
+
+// -----
+// tile_future partial types must be ranked tensors.
+// expected-error @below {{tile_future partial type must be a ranked tensor, but got: 'index'}}
+func.func @bad_future_scalar(%a: !ktdp.tile_future<index>) { return }

--- a/test/Ktdp/inter-tile-reduce-invalid.mlir
+++ b/test/Ktdp/inter-tile-reduce-invalid.mlir
@@ -95,3 +95,38 @@ func.func @bad_producer_overlap(%p: tensor<1x64xf16>) {
   { ^bb0(%gid: index): ktdp.yield_partial %p : tensor<1x64xf16> }
   return
 }
+
+// -----
+// Consumer that did not produce: C = {4g+2..4g+5}, P = {4g..4g+3} -> C not subset
+// of P. Unsupported (open question Q1).
+#q1_prod = affine_set<(i)[g] : (i - 4*g >= 0, -i + 4*g + 3 >= 0)>
+#q1_cons = affine_set<(i)[g] : (i - 4*g - 2 >= 0, -i + 4*g + 5 >= 0)>
+#q1_grp  = affine_set<(g) : (g == 0)>
+func.func @bad_consumer_not_subset(%p: tensor<1x64xf16>, %id: tensor<1x64xf16>) -> tensor<64xf16> {
+  %f = ktdp.inter_tile_produce producer_tiles_per_group = #q1_prod, groups = #q1_grp
+      : tensor<1x64xf16> -> !ktdp.tile_future<tensor<1x64xf16>>
+  { ^bb0(%gid: index): ktdp.yield_partial %p : tensor<1x64xf16> }
+  // expected-error @below {{consumer_tiles_per_group for group 0 is not a subset of producer_tiles_per_group}}
+  %r = ktdp.inter_tile_reduce(%f) consumer_tiles_per_group = #q1_cons, groups = #q1_grp, identity(%id : tensor<1x64xf16>)
+      : !ktdp.tile_future<tensor<1x64xf16>> -> tensor<64xf16>
+  { ^bb0(%l: tensor<1x64xf16>, %rr: tensor<1x64xf16>): ktdp.yield_reduced %l : tensor<1x64xf16> }
+  return %r : tensor<64xf16>
+}
+
+// -----
+// Reduce-to-subset: C = {4g, 4g+1} is a strict subset of P = {4g..4g+3} with >1
+// tile. Spec-legal but UNSUPPORTED by this implementation (only all-reduce and
+// reduce-to-one are supported).
+#rs_prod = affine_set<(i)[g] : (i - 4*g >= 0, -i + 4*g + 3 >= 0)>
+#rs_cons = affine_set<(i)[g] : (i - 4*g >= 0, -i + 4*g + 1 >= 0)>
+#rs_grp  = affine_set<(g) : (g == 0)>
+func.func @bad_reduce_to_subset(%p: tensor<1x64xf16>, %id: tensor<1x64xf16>) -> tensor<64xf16> {
+  %f = ktdp.inter_tile_produce producer_tiles_per_group = #rs_prod, groups = #rs_grp
+      : tensor<1x64xf16> -> !ktdp.tile_future<tensor<1x64xf16>>
+  { ^bb0(%gid: index): ktdp.yield_partial %p : tensor<1x64xf16> }
+  // expected-error @below {{reduce-to-subset is unsupported; only all-reduce and reduce-to-one are supported}}
+  %r = ktdp.inter_tile_reduce(%f) consumer_tiles_per_group = #rs_cons, groups = #rs_grp, identity(%id : tensor<1x64xf16>)
+      : !ktdp.tile_future<tensor<1x64xf16>> -> tensor<64xf16>
+  { ^bb0(%l: tensor<1x64xf16>, %rr: tensor<1x64xf16>): ktdp.yield_reduced %l : tensor<1x64xf16> }
+  return %r : tensor<64xf16>
+}

--- a/test/Ktdp/inter-tile-reduce-invalid.mlir
+++ b/test/Ktdp/inter-tile-reduce-invalid.mlir
@@ -82,3 +82,16 @@ func.func @bad_collapse_nonunit(%p: tensor<96x64xf16>, %id: tensor<96x64xf16>) -
 // tile_future partial types must be ranked tensors.
 // expected-error @below {{tile_future partial type must be a ranked tensor, but got: 'index'}}
 func.func @bad_future_scalar(%a: !ktdp.tile_future<index>) { return }
+
+// -----
+// producer tile sets for distinct groups must be disjoint (§2.1).
+// tiles 3g..3g+3 over groups 0,1: g=0 -> {0,1,2,3}, g=1 -> {3,4,5,6}; tile 3 overlaps.
+#prod_overlap = affine_set<(i)[g] : (i - 3*g >= 0, -i + 3*g + 3 >= 0)>
+#two_groups   = affine_set<(g) : (g >= 0, -g + 1 >= 0)>
+func.func @bad_producer_overlap(%p: tensor<1x64xf16>) {
+  // expected-error @below {{producer_tiles_per_group for groups 0 and 1 are not disjoint}}
+  %f = ktdp.inter_tile_produce producer_tiles_per_group = #prod_overlap, groups = #two_groups
+      : tensor<1x64xf16> -> !ktdp.tile_future<tensor<1x64xf16>>
+  { ^bb0(%gid: index): ktdp.yield_partial %p : tensor<1x64xf16> }
+  return
+}

--- a/test/Ktdp/inter-tile-reduce-roundtrip.mlir
+++ b/test/Ktdp/inter-tile-reduce-roundtrip.mlir
@@ -40,6 +40,34 @@ func.func @reduce_single_role(%partial: tensor<1x64xf16>,
 }
 
 // -----
+// Reduce-to-one: 4 producer tiles per group, only tile 4g consumes the result.
+// Supported (|C| == 1, C subset of P); see §4.1 / open question Q1.
+// -----
+
+#r2o_prod = affine_set<(i)[g] : (i - 4*g >= 0, -i + 4*g + 3 >= 0)>
+#r2o_cons = affine_set<(i)[g] : (i - 4*g == 0)>
+#r2o_grp  = affine_set<(g) : (g == 0)>
+
+// CHECK-LABEL: func.func @reduce_to_one
+func.func @reduce_to_one(%partial: tensor<1x64xf16>,
+                         %add_id: tensor<1x64xf16>) -> tensor<64xf16> {
+  %f = ktdp.inter_tile_produce
+      producer_tiles_per_group = #r2o_prod, groups = #r2o_grp
+      : tensor<1x64xf16> -> !ktdp.tile_future<tensor<1x64xf16>>
+  { ^bb0(%gid: index): ktdp.yield_partial %partial : tensor<1x64xf16> }
+  // CHECK: ktdp.inter_tile_reduce
+  %r = ktdp.inter_tile_reduce(%f)
+      consumer_tiles_per_group = #r2o_cons, groups = #r2o_grp,
+      identity(%add_id : tensor<1x64xf16>)
+      : !ktdp.tile_future<tensor<1x64xf16>> -> tensor<64xf16>
+  { ^bb0(%lhs: tensor<1x64xf16>, %rhs: tensor<1x64xf16>):
+      %s = linalg.add ins(%lhs, %rhs : tensor<1x64xf16>, tensor<1x64xf16>)
+                      outs(%lhs : tensor<1x64xf16>) -> tensor<1x64xf16>
+      ktdp.yield_reduced %s : tensor<1x64xf16> }
+  return %r : tensor<64xf16>
+}
+
+// -----
 // Multi-group reduce (collapse interior unit axis, preserve the group axis).
 // docs/inter-tile-communication.md §8.2.2.
 // -----

--- a/test/Ktdp/inter-tile-reduce-roundtrip.mlir
+++ b/test/Ktdp/inter-tile-reduce-roundtrip.mlir
@@ -1,0 +1,116 @@
+// RUN: ktir-opt "%s" | ktir-opt | FileCheck "%s"
+
+// Inter-tile all-reduce: ktdp.inter_tile_produce + ktdp.inter_tile_reduce.
+// See docs/inter-tile-communication.md (§8.2).
+
+// -----
+// Minimal single-role reduce: collapse the leading unit within-group tile axis.
+// -----
+
+#group_tiles = affine_set<(i)[g] : (i - 32*g >= 0, -i + 32*(g+1) - 1 >= 0)>
+#all_groups  = affine_set<(g) : (g == 0)>
+
+// CHECK-LABEL: func.func @reduce_single_role
+func.func @reduce_single_role(%partial: tensor<1x64xf16>,
+                              %add_id: tensor<1x64xf16>) -> tensor<64xf16> {
+  // CHECK: ktdp.inter_tile_produce producer_tiles_per_group = #{{.*}}, groups = #{{.*}} : tensor<1x64xf16> -> !ktdp.tile_future<tensor<1x64xf16>>
+  %f = ktdp.inter_tile_produce
+      producer_tiles_per_group = #group_tiles,
+      groups = #all_groups
+      : tensor<1x64xf16> -> !ktdp.tile_future<tensor<1x64xf16>>
+  {
+    ^bb0(%gid: index):
+      // CHECK: ktdp.yield_partial %{{.*}} : tensor<1x64xf16>
+      ktdp.yield_partial %partial : tensor<1x64xf16>
+  }
+  // CHECK: ktdp.inter_tile_reduce(%{{.*}}) consumer_tiles_per_group = #{{.*}}, groups = #{{.*}}, identity(%{{.*}} : tensor<1x64xf16>) : !ktdp.tile_future<tensor<1x64xf16>> -> tensor<64xf16>
+  %r = ktdp.inter_tile_reduce(%f)
+      consumer_tiles_per_group = #group_tiles,
+      groups = #all_groups,
+      identity(%add_id : tensor<1x64xf16>)
+      : !ktdp.tile_future<tensor<1x64xf16>> -> tensor<64xf16>
+  {
+    ^bb0(%lhs: tensor<1x64xf16>, %rhs: tensor<1x64xf16>):
+      %s = linalg.add ins(%lhs, %rhs : tensor<1x64xf16>, tensor<1x64xf16>)
+                      outs(%lhs : tensor<1x64xf16>) -> tensor<1x64xf16>
+      // CHECK: ktdp.yield_reduced %{{.*}} : tensor<1x64xf16>
+      ktdp.yield_reduced %s : tensor<1x64xf16>
+  }
+  return %r : tensor<64xf16>
+}
+
+// -----
+// Multi-group reduce (collapse interior unit axis, preserve the group axis).
+// docs/inter-tile-communication.md §8.2.2.
+// -----
+
+#mg_tiles  = affine_set<(i)[g] : (i - 4*g >= 0, -i + 4*g + 3 >= 0)>
+#mg_groups = affine_set<(g) : (g >= 0, -g + 7 >= 0)>
+
+// CHECK-LABEL: func.func @reduce_multi_group
+func.func @reduce_multi_group(%partial: tensor<128x1x1x64xf16>,
+                              %add_id: tensor<128x1x1x64xf16>) -> tensor<128x1x64xf16> {
+  // CHECK: ktdp.inter_tile_produce
+  %f = ktdp.inter_tile_produce
+      producer_tiles_per_group = #mg_tiles,
+      groups = #mg_groups
+      : tensor<128x1x1x64xf16> -> !ktdp.tile_future<tensor<128x1x1x64xf16>>
+  {
+    ^bb0(%gid: index):
+      ktdp.yield_partial %partial : tensor<128x1x1x64xf16>
+  }
+  // CHECK: ktdp.inter_tile_reduce
+  %r = ktdp.inter_tile_reduce(%f)
+      consumer_tiles_per_group = #mg_tiles,
+      groups = #mg_groups,
+      identity(%add_id : tensor<128x1x1x64xf16>)
+      : !ktdp.tile_future<tensor<128x1x1x64xf16>> -> tensor<128x1x64xf16>
+  {
+    ^bb0(%lhs: tensor<128x1x1x64xf16>, %rhs: tensor<128x1x1x64xf16>):
+      %s = linalg.add ins(%lhs, %rhs : tensor<128x1x1x64xf16>, tensor<128x1x1x64xf16>)
+                      outs(%lhs : tensor<128x1x1x64xf16>) -> tensor<128x1x1x64xf16>
+      ktdp.yield_reduced %s : tensor<128x1x1x64xf16>
+  }
+  return %r : tensor<128x1x64xf16>
+}
+
+// -----
+// Multi-role (argmax-style, N=2) reduce with per-tile dependency set.
+// -----
+
+#bf_tiles  = affine_set<(i)[g] : (i - 4*g >= 0, -i + 4*g + 3 >= 0)>
+#bf_groups = affine_set<(g) : (g >= 0, -g + 7 >= 0)>
+#bf_dep    = affine_set<(p)[c, g] : (p + c - 8*g - 3 == 0)>
+
+// CHECK-LABEL: func.func @reduce_argmax
+func.func @reduce_argmax(%pv: tensor<1x64xf32>, %pi: tensor<1x64xi32>,
+                         %iv: tensor<1x64xf32>, %ii: tensor<1x64xi32>)
+    -> (tensor<64xf32>, tensor<64xi32>) {
+  %f = ktdp.inter_tile_produce
+      producer_tiles_per_group = #bf_tiles,
+      groups = #bf_groups
+      : tensor<1x64xf32>, tensor<1x64xi32>
+        -> !ktdp.tile_future<tensor<1x64xf32>, tensor<1x64xi32>>
+  {
+    ^bb0(%gid: index):
+      ktdp.yield_partial %pv, %pi : tensor<1x64xf32>, tensor<1x64xi32>
+  }
+  // CHECK: producer_dependency_per_consumer = #{{.*}}
+  %rv, %ri = ktdp.inter_tile_reduce(%f)
+      consumer_tiles_per_group = #bf_tiles,
+      groups = #bf_groups,
+      producer_dependency_per_consumer = #bf_dep,
+      identity(%iv : tensor<1x64xf32>, %ii : tensor<1x64xi32>)
+      : !ktdp.tile_future<tensor<1x64xf32>, tensor<1x64xi32>>
+        -> tensor<64xf32>, tensor<64xi32>
+  {
+    ^bb0(%lv: tensor<1x64xf32>, %li: tensor<1x64xi32>,
+         %rv2: tensor<1x64xf32>, %ri2: tensor<1x64xi32>):
+      // 2-adic argmax combiner: keep the larger value and its index.
+      %take_lhs = arith.cmpf ogt, %lv, %rv2 : tensor<1x64xf32>
+      %max_v = arith.maxnumf %lv, %rv2 : tensor<1x64xf32>
+      %max_i = arith.select %take_lhs, %li, %ri2 : tensor<1x64xi1>, tensor<1x64xi32>
+      ktdp.yield_reduced %max_v, %max_i : tensor<1x64xf32>, tensor<1x64xi32>
+  }
+  return %rv, %ri : tensor<64xf32>, tensor<64xi32>
+}

--- a/test/Ktdp/tile-future-type.mlir
+++ b/test/Ktdp/tile-future-type.mlir
@@ -1,0 +1,15 @@
+// RUN: ktir-opt "%s" | ktir-opt | FileCheck "%s"
+
+// CHECK-LABEL: func.func @future_single
+// CHECK-SAME: !ktdp.tile_future<tensor<1x64xf16>>
+func.func @future_single(%arg0: !ktdp.tile_future<tensor<1x64xf16>>)
+    -> !ktdp.tile_future<tensor<1x64xf16>> {
+  return %arg0 : !ktdp.tile_future<tensor<1x64xf16>>
+}
+
+// CHECK-LABEL: func.func @future_multi
+// CHECK-SAME: !ktdp.tile_future<tensor<128xf32>, tensor<128xi32>>
+func.func @future_multi(%arg0: !ktdp.tile_future<tensor<128xf32>, tensor<128xi32>>)
+    -> !ktdp.tile_future<tensor<128xf32>, tensor<128xi32>> {
+  return %arg0 : !ktdp.tile_future<tensor<128xf32>, tensor<128xi32>>
+}


### PR DESCRIPTION
Implements the all-reduce pattern from `docs/inter-tile-communication.md` (PR #23).
The doc lands four ops; this PR lands the two needed for all-reduce plus the
shared scaffolding (future type, terminators) the other patterns will reuse.

## 1. What is implemented (and where the rest goes)

**Implemented:**
- Type `!ktdp.tile_future<T_p_1, ...>` — variadic partial roles (`KtdpTypes.{td,cpp}`).
- Terminators `ktdp.yield_partial`, `ktdp.yield_reduced` (`KtdpOps.td`).
- `ktdp.inter_tile_produce` — producer region, `producer_tiles_per_group`/`groups`
  affine sets, single-use future result.
- `ktdp.inter_tile_reduce` — combiner region (2N args), `identity` operands,
  optional `producer_dependency_per_consumer`, collapsed-axis result.
  Verifiers in `KtdpOps.cpp`.

**Reduce variants — supported modes and the spec relationship.** The verifier
checks `consumer_tiles_per_group` (C) against `producer_tiles_per_group` (P) per
group `g`. The spec (§4.1, §4.5, open question Q1) and our policy differ — this
is a deliberate, documented restriction, **not** spec enforcement:

| Relation per group `g` | Spec status | This impl |
|---|---|---|
| `C == P` | mandated valid (all-reduce) | **accept** |
| `\|C\| == 1`, `C ⊆ P` | supported (reduce-to-one) | **accept** |
| `1 < \|C\| < \|P\|`, `C ⊆ P` | **spec-supported** (reduce-to-subset) | **reject — "unsupported"** (our restriction; IR is spec-legal) |
| `C ⊄ P` (a consumer that did not produce) | **open (Q1)** | **reject — "unsupported (Q1)"** |

The hard, spec-mandated rule is `C ⊆ P`; everything tighter (only all-reduce +
reduce-to-one) is our choice. Error messages say **"unsupported"**, never
"invalid", so we never misrepresent the spec. (`groups` must-match is a true
spec rule — still TODO, see §2.)

**Future patterns slot into the same files, no new scaffolding:**
- Broadcast → new `ktdp.inter_tile_consume` op in `KtdpOps.{td,cpp}` (consumes
  the existing future, no combiner).
- Reduce-scatter → new `ktdp.inter_tile_reduce_scatter` op, = reduce + a
  `scatter_dimension` attr + sliced result type.
- Additional consumers per future / per-tile sync → relaxing the single-use
  rule (§2) + `producer_dependency_per_consumer` subset/coverage checks, all in
  `InterTileReduceOp::verify()` / the new consume op's verifier.
- Gather, scatter → new ops, same pattern.

## 2. Polyhedral checks — status and where they go

Implemented via enumeration assuming that upper bounds are present; remaining checks have TODO markers.

| Check | Lives in | Status |
|---|---|---|
| Producer group disjointness (§2.1) | `InterTileProduceOp::verify` | ✅ done (enumerated) |
| Consumer-vs-producer: `C ⊆ P` + supported-mode gate | `InterTileReduceOp::verify` | ✅ done (enumerated) |
| `groups` matches between produce & reduce (§4.1) | `InterTileReduceOp::verify` | ✅ done (enumerated) |
| `producer_dependency_per_consumer` subset + coverage (§3.1, §6) | `InterTileReduceOp::verify` | ✅ done (enumerated) |
| Symbolic variants (unbounded `groups` range) of the two done checks | both verifiers | NOT DOING |

**Enumerated approach (all done checks).** When the `groups` range is statically
bounded, pin each concrete `g` via `FlatLinearValueConstraints(IntegerSet)` +
`setAndEliminate`, then enumerate tile ids into `DenseSet<int64_t>` and check by
set membership — no Presburger set-operation queries. New CMake dependency:
`MLIRAnalysis` (not `MLIRPresburger`).
- **Disjointness:** for each concrete `g`, enumerate `tilesOf(producerSet, g)`
  into a `DenseSet`; check pairwise intersection across groups by membership
  lookup.
- **Consumer-vs-producer:** enumerate `tilesOf(consumerSet, g)` and
  `tilesOf(producerSet, g)`; check `C ⊆ P` by membership, then accept iff
  `C == P` (all-reduce) or `|C| == 1` (reduce-to-one).
- **`groups`-match:** direct `IntegerSet` value equality on the two attrs.
- **Dependency subset/coverage:** enumerate `depTilesOf(depSet, c, g)` and
  verify each `p` is in `P(g)` (subset), then verify every `p ∈ P(g)` is
  covered by some consumer's dependency set (coverage).

A pure-Presburger alternative (Option A) was also designed — disjointness and
subset become relation-emptiness queries over `(i, g)` without any loop; the
`|C|==1` mode gate requires a two-tile-variable construction. See the PR
discussion for the full design if unbounded-groups support is ever needed.

When `groups` is **not** statically bounded, all checks are skipped with a
`// TODO(inter-tile): symbolic` marker (a symbolic-`g` emptiness query is the
follow-up).

**Single-use invariants — both now covered:**
- ✅ **Future → one consumer:** `InterTileProduceOp::verify` enforces the future
  has exactly one use.
- ✅ **Consumer → one producer (in effect):** the consumer-vs-producer check
  reaches the producer via `getFuture().getDefiningOp<InterTileProduceOp>()`; a
  future not defined by a single `inter_tile_produce` makes the cross-op
  comparison unavailable (the check defers). Combined with the future single-use
  rule, a well-formed reduce consumes exactly one producer's future.

## 3. Tests — added, covered, and gaps

**Added** (`test/Ktdp/`):
- `tile-future-type.mlir` — type round-trip (single + multi-role).
- `inter-tile-reduce-roundtrip.mlir` — single-group, multi-group (preserved
  group axis), **reduce-to-one** (`|C|==1`, accepted), and N=2 argmax with a
  `producer_dependency_per_consumer` set. The argmax case uses a real 2-adic
  combiner (`cmpf ogt` / `maxnumf` / `select` — the same body `tt.reduce`
  argmax lowers to), not a passthrough, so it exercises an actual value+index
  correlated reduction.
- `inter-tile-reduce-invalid.mlir` — 9 negatives: yield arity, future
  multi-use, identity-type mismatch, collapse rank, non-unit collapse,
  non-tensor future partial, **producer-group non-disjointness** (§2.1),
  **consumer not subset of producer** (Q1, unsupported), and
  **reduce-to-subset** (spec-legal but unsupported).

Both full published examples (§8.2.1 96×64, §8.2.2 128×8×12×64) round-trip
through `ktir-opt` unchanged.

**Covers:** type shape, region arity, collapsed-axis rule, identity match,
future single-use, variadic (argmax) structure, producer-group disjointness,
and the full consumer-vs-producer mode matrix (accept all-reduce + reduce-to-one;
reject reduce-to-subset and `C⊄P`).

**Test gaps (track with §2):**
- No negatives for `groups` mismatch or dependency-set subset/coverage (those
  checks are still TODO).
- No symbolic (unbounded-`groups`) tests — both done checks defer there.
- No use-by-non-consumer-tile (§4.5 ownership, open question Q4).

## Spec-compliance summary

All-reduce and reduce-to-one: **validated** (`C ⊆ P` mandated check + mode gate).
Reduce-to-subset and `C ⊄ P` (Q1): **rejected as unsupported** — a deliberate
restriction, surfaced with "unsupported" messages, not spec violations.
Broadcast, reduce-scatter, per-tile sync, gather, scatter: **not in this PR.**
Remaining spec checks (`groups` match, dependency subset/coverage) and the
symbolic-`groups` variants are documented TODOs at known sites.